### PR TITLE
[WIP] Fixes #8: Avoid extra password prompts and changed options to be one set

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,14 @@ Released: not yet
   option. In force mode, the deactivation operation is permitted when the
   LPAR status is "operating".
 
+* Changed the way the CLI deals with global options when invoked in interactive
+  mode: Previously, each subcommand had its own set of options that were
+  defaulted from the options specified in the zhmc command line. Now, there is
+  only one set of options that is initially set from the zhmc command line,
+  and subsequently modified with the options specified for each subcommand.
+  This means options on subcommands are "remembered" for subsequent
+  subcommands. Related to issues #176 and #225.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -51,6 +59,9 @@ Released: not yet
   (force=True was hard coded for deactivate, before this change).
 
 * Added support for a ``--activation-profile-name`` option in LPAR activate.
+
+* In the interactive mode of the CLI, the password is now reused between
+  subcommands (issue #176).
 
 **Known issues:**
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -93,6 +93,12 @@ However, the zhmc shell will prompt for a password only once during its
 invocation, while the standalone command will prompt for a password every time.
 See also `Environment variables and avoiding password prompts`_.
 
+In interactive mode, there is only one set of general options. Therefore,
+any general options specified on an interactively typed subcommand modify
+that one set of options, and they are available as defaults to the next
+subcommand. Changing host, userid or password on a subcommand resets the
+session with the HMC and drives a new session creation.
+
 The internal commands ``:?``, ``:h``, or ``:help`` display general help
 information for external and internal commands:
 
@@ -336,7 +342,6 @@ command line. This can be done in either of two ways:
 
 The ZHMC_HOST, ZHMC_USERID, and ZHMC_PASSWORD environment variables act as
 defaults for the corresponding command line options.
-
 
 .. _`CLI commands`:
 

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -228,6 +228,7 @@ class CmdContext(object):
         return self._spinner
 
     def execute_cmd(self, cmd):
+
         if self._session is None:
             if isinstance(self._session_id, zhmcclient_mock.FakedSession):
                 self._session = self._session_id

--- a/zhmccli/zhmccli.py
+++ b/zhmccli/zhmccli.py
@@ -120,42 +120,11 @@ def cli(ctx, host, userid, password, output_format, transpose, error_format,
         decorators.
     """
 
-    # Concept: In interactive mode, the global options specified in the command
-    # line are used as defaults for the commands that are issued interactively.
-    # The interactive commands may override these options.
-    # This requires being able to determine for each option whether it has been
-    # specified. This is the reason the options don't define defaults in the
-    # decorators that define them.
-
-    if ctx.obj is None:
-        # We are in command mode or are processing the command line options in
-        # interactive mode.
-        # We apply the documented option defaults.
-        if output_format is None:
-            output_format = DEFAULT_OUTPUT_FORMAT
-        if transpose is None:
-            transpose = False
-        if error_format is None:
-            error_format = DEFAULT_ERROR_FORMAT
-        if timestats is None:
-            timestats = DEFAULT_TIMESTATS
-    else:
-        # We are processing an interactive command.
-        # We apply the option defaults from the command line options.
-        if host is None:
-            host = ctx.obj.host
-        if userid is None:
-            userid = ctx.obj.userid
-        if password is None:
-            password = ctx.obj._password
-        if output_format is None:
-            output_format = ctx.obj.output_format
-        if transpose is None:
-            transpose = ctx.obj.transpose
-        if error_format is None:
-            error_format = ctx.obj.error_format
-        if timestats is None:
-            timestats = ctx.obj.timestats
+    # Concept: We maintain exactly one set of options in one instance of
+    # CmdContext. That set of options is initially populated with the options
+    # from the command line and their defaults. Each subcommand operates on
+    # the same set of options, and any options specified by a subcommand will
+    # be used to update that one set of options.
 
     if transpose and output_format == 'json':
         raise_click_exception(
@@ -265,12 +234,32 @@ def cli(ctx, host, userid, password, output_format, transpose, error_format,
                                         format(cmd=ctx.invoked_subcommand),
                                         error_format)
 
-    # We create a command context for each command: An interactive command has
-    # its own command context different from the command context for the
-    # command line.
-    ctx.obj = CmdContext(host, userid, password, output_format, transpose,
-                         error_format, timestats, session_id,
-                         get_password_via_prompt)
+    default_session_id = os.environ.get('ZHMC_SESSION_ID', None)
+
+    if ctx.obj is None:
+        ctx.obj = CmdContext(
+            host,  # defaulted by click.option (can still be None)
+            userid,   # defaulted by click.option (can still be None)
+            password,  # defaulted by click.option (can still be None)
+            output_format=DEFAULT_OUTPUT_FORMAT,
+            timestats=DEFAULT_TIMESTATS,
+            session_id=default_session_id,
+            get_password=get_password_via_prompt)
+    else:
+        if host:
+            ctx.obj._host = host
+        if userid:
+            ctx.obj._userid = userid
+        if password:
+            ctx.obj._password = password
+        if host or userid or password:
+            # We need a new session if any of those changes
+            ctx.obj._session = None
+            ctx.obj._session_id = None
+        if output_format:
+            ctx.obj._output_format = output_format
+        if timestats:
+            ctx.obj._timestats = timestats
 
     # Invoke default command
     if ctx.invoked_subcommand is None:


### PR DESCRIPTION
Currently WIP, because it is really not clear that a single context is a good thing to have.

Please pay particular attention to the fact that we now have only one set of options in interactive mode, so the options used by a subcommand are still in place for the next subcommand.