### PR TITLE
Various changes for passing Travis and Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,41 +42,42 @@ matrix:
       python: "3.6"
       env:
         - PACKAGE_LEVEL=latest
-    - os: linux
-      language: python
-      python: "pypy-5.3.1"  # Python 2.7.10
-      env:
-        - PACKAGE_LEVEL=minimum
-      before_install:
-        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
-    - os: osx
-      language: generic
-      python:
-      env:
-        - PACKAGE_LEVEL=minimum
-        - PYTHON=2
-    - os: osx
-      language: generic
-      python:
-      env:
-        - PACKAGE_LEVEL=latest
-        - PYTHON=2
-      before_install:
-        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
-    - os: osx
-      language: generic
-      python:
-      env:
-        - PACKAGE_LEVEL=minimum
-        - PYTHON=3
-      before_install:
-        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
-    - os: osx
-      language: generic
-      python:
-      env:
-        - PACKAGE_LEVEL=latest
-        - PYTHON=3
+#    - os: linux
+#      language: python
+#      python: "pypy-5.3.1"  # Python 2.7.10
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#      before_install:
+#        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
+# TODO: Re-enable osx support once Travis has better OS-X capacity
+#    - os: osx
+#      language: generic
+#      python:
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#        - PYTHON=2
+#    - os: osx
+#      language: generic
+#      python:
+#      env:
+#        - PACKAGE_LEVEL=latest
+#        - PYTHON=2
+#      before_install:
+#        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
+#    - os: osx
+#      language: generic
+#      python:
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#        - PYTHON=3
+#      before_install:
+#        - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then exit 0; fi
+#    - os: osx
+#      language: generic
+#      python:
+#      env:
+#        - PACKAGE_LEVEL=latest
+#        - PYTHON=3
 
 # commands to install dependencies
 install:

--- a/Makefile
+++ b/Makefile
@@ -158,9 +158,9 @@ help:
 _pip:
 	@echo 'Installing/upgrading pip, setuptools, wheel and pbr with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
 	$(PIP_CMD) install $(pip_level_opts) pip setuptools wheel pbr
-	#@echo "Temp fix: Install setuptools a second time to circumvent import error for build_clib on Travis"
-	#$(PIP_CMD) install $(pip_level_opts) setuptools
-	#$(PIP_CMD) list
+	@echo "Temp fix: Install setuptools a second time to circumvent import error for build_clib on Travis"
+	$(PIP_CMD) install $(pip_level_opts) setuptools
+	$(PIP_CMD) list
 	# TODO: Final solution for the above temp fix. See also pip issue https://github.com/pypa/pip/issues/4724
 
 .PHONY: develop

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,3 +27,9 @@ This is the base version for this change log. The zhmccli project was
 split off of the python-zhmcclient project based upon its released
 version 0.17.0. For prior changes, see the change log of the
 python-zhmcclient project.
+
+Additional changes:
+
+* Fixed the issue that the readline module is not available in
+  standard python on Windows, by using the pyreadline module
+  in that case.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -55,6 +55,7 @@ requests===2.12.4
 six===1.10.0
 stomp.py===4.1.15
 tabulate===0.7.7
+pyreadline===2.1 #; sys_platform == "win32"
 
 
 # Indirect dependencies for runtime (must be consistent with requirements.txt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ click-spinner>=0.1.6 # MIT
 progressbar2>=3.12.0 # BSD
 six>=1.10.0 # MIT
 tabulate>=0.7.7 # MIT
-
+pyreadline>=2.1; sys_platform == "win32" # BSD
 
 # Indirect dependencies (commented out, only listed to document their license):
 

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -18,12 +18,18 @@ import json
 from collections import OrderedDict
 import sys
 import threading
-import readline  # noqa: F401
 import re
 import six
 import click
 import click_spinner
 from tabulate import tabulate
+
+# Importing readline makes interactive mode keep history
+try:
+    import readline  # noqa: F401
+except ImportError:
+    # No readline on Windows
+    import pyreadline as readline  # noqa: F401
 
 import zhmcclient
 


### PR DESCRIPTION
Ready for review and merge into 0.18.0.

Changes:
* Circumvented Travis issue with build_clib.
* Fixed issue with no readline module on Windows.
* Disabled OS-X and pypy on Travis for the time being. 