### PR TITLE
(#4) Release 0.18.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,4 +1,4 @@
-.. Copyright 2016-2017 IBM Corp. All Rights Reserved.
+.. Copyright 2017 IBM Corp. All Rights Reserved.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ Change log
 Version 0.18.0
 ^^^^^^^^^^^^^^
 
-Released: not yet
+Released: 2017-10-19
 
 This is the base version for this change log. The zhmccli project was
 split off of the python-zhmcclient project based upon its released

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -45,6 +45,7 @@ pbr===1.10.0
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
 
+zhmcclient===0.18.0
 click===6.6
 click-repl===0.1.0
 click-spinner===0.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,7 @@
 
 # Direct dependencies (except pip, setuptools, wheel, pbr):
 
-# TODO: Switch to zhmcclient>=0.18.0 once released.
-git+https://github.com/zhmcclient/python-zhmcclient.git@master#egg=zhmcclient
-# zhmcclient>=0.18.0 # Apache
+zhmcclient>=0.18.0 # Apache
 
 click>=6.6 # BSD
 click-repl>=0.1.0 # MIT


### PR DESCRIPTION
**Note:** This PR uses the released version of zhmcclient 0.18.0, and therefore will fail until that version is released.
**Note:** When releasing zhmccli 0.18.0, the 0.18.0 tag still needs to be added once this PR is merged.