### PR TITLE
Manual Travis+Appveyor CI runs with full set of environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@
 name: test
 
 on:
-  # schedule:
-  # # minute hour day_of_month month day_of_week
-  # - cron:  '10 21 * * 0'  # Every sunday at 21:10 UTC
+  schedule:
+  # minute hour day_of_month month day_of_week
+  - cron:  '10 21 * * 0'  # Every sunday at 21:10 UTC
   push:
     branches: [ master, stable_0.19 ]
   pull_request:
@@ -18,43 +18,46 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 20
-      # # The matrix for the all-environment pull request:
-      # matrix:
-      #   os: [ubuntu-latest, macos-latest, windows-latest]
-      #   python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9]
-      #   package_level: [minimum, latest]
-      #   exclude:
-      #   - os: macos-latest
-      #     python-version: 3.4
-      #     package_level: minimum
-      #   - os: macos-latest
-      #     python-version: 3.4
-      #     package_level: latest
-      #   - os: windows-latest
-      #     python-version: 3.4
-      #     package_level: minimum
-      #   - os: windows-latest
-      #     python-version: 3.4
-      #     package_level: latest
-      # The matrix for normal pull requests:
+      # The matrix for the all-environment pull request:
       matrix:
-        os: [ubuntu-latest]
-        python-version: [2.7, 3.4, 3.8]  # TODO: Add 3.9
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9]
         package_level: [minimum, latest]
         exclude:
-        - os: ubuntu-latest
+        - os: ubuntu-latest  # TODO: Fix this env
           python-version: 3.4
           package_level: latest
-        include:
         - os: macos-latest
-          python-version: 3.8  # TODO: Change to 3.9
+          python-version: 3.4
+          package_level: minimum
+        - os: macos-latest
+          python-version: 3.4
           package_level: latest
         - os: windows-latest
-          python-version: 3.8  # TODO: Change to 3.9
+          python-version: 3.4
           package_level: minimum
         - os: windows-latest
-          python-version: 3.8  # TODO: Change to 3.9
+          python-version: 3.4
           package_level: latest
+      # # The matrix for normal pull requests:
+      # matrix:
+      #   os: [ubuntu-latest]
+      #   python-version: [2.7, 3.4, 3.8]  # TODO: Add 3.9
+      #   package_level: [minimum, latest]
+      #   exclude:
+      #   - os: ubuntu-latest  # TODO: Fix this env
+      #     python-version: 3.4
+      #     package_level: latest
+      #   include:
+      #   - os: macos-latest
+      #     python-version: 3.8  # TODO: Change to 3.9
+      #     package_level: latest
+      #   - os: windows-latest
+      #     python-version: 3.8  # TODO: Change to 3.9
+      #     package_level: minimum
+      #   - os: windows-latest
+      #     python-version: 3.8  # TODO: Change to 3.9
+      #     package_level: latest
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo


### PR DESCRIPTION
**!! Do not merge this PR !! This PR stays on its branch and is never merged.**

The change in this PR causes Travis and Appveyor to run with the full set of test environments, compared to the other branches which run with a minimal set of test environments.

**Usage:**

* This PR is run automatically on Travis as a daily build.
* To trigger a manual build on both Travis and Appveyor, rebase the branch of this PR to master:
  ```
  git checkout master
  git pull
  git checkout manual-ci-run
  git rebase master
  git push -f
  ```
* For build results, see branch `manual-ci-run` in https://travis-ci.org/zhmcclient/zhmccli/branches.

Note: If you make changes to .travis.yml, the automatic daily build on Travis will not pick them up until you rebase this PR on them.