### PR TITLE
(#2) Fixed that CONSOLE_LOGGER_NAME was not migrated from zhmcclient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,12 +156,9 @@ help:
 
 .PHONY: _pip
 _pip:
+	$(PYTHON_CMD) remove_duplicate_setuptools.py
 	@echo 'Installing/upgrading pip, setuptools, wheel and pbr with PACKAGE_LEVEL=$(PACKAGE_LEVEL)'
 	$(PIP_CMD) install $(pip_level_opts) pip setuptools wheel pbr
-	@echo "Temp fix: Install setuptools a second time to circumvent import error for build_clib on Travis"
-	$(PIP_CMD) install $(pip_level_opts) setuptools
-	$(PIP_CMD) list
-	# TODO: Final solution for the above temp fix. See also pip issue https://github.com/pypa/pip/issues/4724
 
 .PHONY: develop
 develop: _pip

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,7 @@
 Change log
 ----------
 
+
 Version 0.18.0
 ^^^^^^^^^^^^^^
 
@@ -33,3 +34,8 @@ Additional changes:
 * Fixed the issue that the readline module is not available in
   standard python on Windows, by using the pyreadline module
   in that case.
+
+* Fixed a flawed setup of setuptools in Python 2.7 on the Travis CI, where
+  the metadata directory of setuptools existed twice, by adding a script
+  `remove_duplicate_setuptools.py` that removes the moot copy of the metadata
+  directory (python-zhmcclient issue #434).

--- a/remove_duplicate_setuptools.py
+++ b/remove_duplicate_setuptools.py
@@ -1,0 +1,60 @@
+#!/bin/env python
+"""
+This script removes duplicated dist-info directories of setuptools, which
+happen to exist on the Travis CI in their Ubuntu 14.04 (trusty) distro:
+  site-packages/setuptools                  <- contains 36.3.0
+  site-packages/setuptools-36.0.1.dist-info <- duplicate to be removed
+  site-packages/setuptools-36.3.0.dist-info
+"""
+
+import sys
+import os
+import re
+import glob
+import importlib
+import shutil
+
+
+def remove_duplicate_metadata_dirs(package_name):
+    """Remove duplicate metadata directories of a package."""
+
+    print("Removing duplicate metadata directories of package: {}".
+          format(package_name))
+
+    module = importlib.import_module(package_name)
+
+    py_mn = "{}.{}".format(*sys.version_info[0:2])
+    print("Current Python version: {}".format(py_mn))
+
+    version = module.__version__
+    print("Version of imported {} package: {}".format(package_name, version))
+
+    site_dir = os.path.dirname(os.path.dirname(module.__file__))
+    print("Site packages directory of imported package: {}".format(site_dir))
+
+    metadata_dirs = []
+    metadata_dirs.extend(glob.glob(os.path.join(
+        site_dir, '{}-*.dist-info'.format(package_name))))
+    metadata_dirs.extend(glob.glob(os.path.join(
+        site_dir, '{}-*-py{}.egg-info'.format(package_name, py_mn))))
+
+    for d in metadata_dirs:
+
+        m = re.search(r'/{}-([0-9.]+)(\.di|-py)'.format(package_name), d)
+
+        if not m:
+            print("Warning: Could not parse metadata directory: {}".format(d))
+            continue
+
+        d_version = m.group(1)
+
+        if d_version == version:
+            print("Found matching metadata directory: {}".format(d))
+            continue
+
+        print("Removing duplicate metadata directory: {}".format(d))
+        shutil.rmtree(d)
+
+
+if __name__ == '__main__':
+    remove_duplicate_metadata_dirs('setuptools')

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -18,7 +18,7 @@ import logging
 import click
 
 import zhmcclient
-from .zhmccli import cli
+from .zhmccli import cli, CONSOLE_LOGGER_NAME
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     part_console, raise_click_exception
@@ -341,7 +341,7 @@ def cmd_lpar_load(cmd_ctx, cpc_name, lpar_name, load_address, options):
 
 def cmd_lpar_console(cmd_ctx, cpc_name, lpar_name, options):
 
-    logger = logging.getLogger(zhmcclient.CONSOLE_LOGGER_NAME)
+    logger = logging.getLogger(CONSOLE_LOGGER_NAME)
 
     client = zhmcclient.Client(cmd_ctx.session)
     lpar = find_lpar(cmd_ctx, client, cpc_name, lpar_name)

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -21,7 +21,7 @@ import logging
 import click
 
 import zhmcclient
-from .zhmccli import cli
+from .zhmccli import cli, CONSOLE_LOGGER_NAME
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     part_console, raise_click_exception
@@ -731,7 +731,7 @@ def cmd_partition_delete(cmd_ctx, cpc_name, partition_name):
 
 def cmd_partition_console(cmd_ctx, cpc_name, partition_name, options):
 
-    logger = logging.getLogger(zhmcclient.CONSOLE_LOGGER_NAME)
+    logger = logging.getLogger(CONSOLE_LOGGER_NAME)
 
     client = zhmcclient.Client(cmd_ctx.session)
     partition = find_partition(cmd_ctx, client, cpc_name, partition_name)

--- a/zhmccli/zhmccli.py
+++ b/zhmccli/zhmccli.py
@@ -40,6 +40,8 @@ DEFAULT_LOG = 'all=warning'
 DEFAULT_LOG_DESTINATION = 'stderr'
 DEFAULT_SYSLOG_FACILITY = 'user'
 
+CONSOLE_LOGGER_NAME = 'zhmccli.console'
+
 ERROR_FORMATS = ['msg', 'def']
 
 SYSLOG_ADDRESSES = {
@@ -223,7 +225,7 @@ def cli(ctx, host, userid, password, output_format, transpose, error_format,
                     logger.addHandler(handler)
                     logger.setLevel(level)
                 if log_comp == 'console':
-                    logger = logging.getLogger(zhmcclient.CONSOLE_LOGGER_NAME)
+                    logger = logging.getLogger(CONSOLE_LOGGER_NAME)
                     logger.addHandler(handler)
                     logger.setLevel(level)
 


### PR DESCRIPTION
**Note:** This PR is on top of PR #21.
Ready for review and merge (still into 0.18.0).