### PR TITLE
Update requirements.txt to fix zhmcclient branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@
 # Direct dependencies (except pip, setuptools, wheel, pbr):
 
 # TODO: Switch to zhmcclient>=0.19.0 once released.
-git+https://github.com/zhmcclient/python-zhmcclient.git@andy/add-lpar-force#egg=zhmcclient
+git+https://github.com/zhmcclient/python-zhmcclient.git@master#egg=zhmcclient
 # zhmcclient>=0.19.0 # Apache
 
 click>=6.6 # BSD


### PR DESCRIPTION
Zhmccli depends on the functionality introduced in zhmcclient with PR zhmcclient/python-zhmcclient#461. Its branch was deleted when it was merged, causing zhmccli to fail. This change pulls in the master branch of zhmcclient, until zhmcclient 0.19.0 will be released.