### PR TITLE
Make it easier to execute the test cases

### DIFF
--- a/tests/function/test_global_opts.py
+++ b/tests/function/test_global_opts.py
@@ -40,7 +40,7 @@ class TestGlobalOptions(object):
 
         assert_rc(0, rc, stdout, stderr)
         assert stdout.startswith(
-            "Usage: zhmc [GENERAL-OPTIONS] COMMAND [ARGS]...\n"), \
+            "Usage: __main__.py [GENERAL-OPTIONS] COMMAND [ARGS]...\n"), \
             "stdout={!r}".format(stdout)
         assert stderr == ""
 
@@ -50,5 +50,6 @@ class TestGlobalOptions(object):
         rc, stdout, stderr = call_zhmc_child(['--version'])
 
         assert_rc(0, rc, stdout, stderr)
-        assert re.match(r'^zhmc, version [0-9]+\.[0-9]+\.[0-9]+', stdout)
+        assert re.match(r'^__main__.py, version [0-9]+\.[0-9]+\.[0-9]+',
+                        stdout)
         assert stderr == ""

--- a/tests/function/test_info.py
+++ b/tests/function/test_info.py
@@ -47,7 +47,7 @@ class TestInfo(object):
 
         assert_rc(0, rc, stdout, stderr)
         assert stdout.startswith(
-            "Usage: zhmc info [OPTIONS]\n"), \
+            "Usage: __main__.py info [OPTIONS]\n"), \
             "stdout={!r}".format(stdout)
         assert stderr == ""
 

--- a/tests/function/utils.py
+++ b/tests/function/utils.py
@@ -32,10 +32,7 @@ from zhmccli.zhmccli import cli
 
 def call_zhmc_child(args, env=None):
     """
-    Invoke the 'zhmc' command as a child process.
-
-    This requires that the 'zhmc' command is installed in the current Python
-    environment.
+    Invoke the 'python -m zhmccli' command as a child process.
 
     Parameters:
 
@@ -65,7 +62,7 @@ def call_zhmc_child(args, env=None):
           An empty string, if there was no data.
     """
 
-    cli_cmd = u'zhmc'
+    cmd_args = [u'python', u'-m', u'zhmccli']
 
     if env is None:
         env = {}
@@ -95,7 +92,6 @@ def call_zhmc_child(args, env=None):
             os.environ[name] = value
 
     assert isinstance(args, (list, tuple))
-    cmd_args = [cli_cmd]
     for arg in args:
         if not isinstance(arg, six.text_type):
             arg = arg.decode('utf-8')

--- a/zhmccli/__main__.py
+++ b/zhmccli/__main__.py
@@ -1,0 +1,26 @@
+# Copyright 2019 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Module containing the entry point for CLI execution
+"""
+
+from __future__ import absolute_import
+
+from zhmccli.zhmccli import cli
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
Remove the requirement that ``zhmccli`` must be installed to run the tests.