### PR TITLE
Excluded pylint 2.6.1 and astroid 2.5.0 to circumvent AttributeError

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -60,12 +60,16 @@ readme-renderer>=25.0; python_version >= '3.5'
 # Pylint 1.x / astroid 1.x supports py27 and py34/35/36
 # Pylint 2.0 / astroid 2.0 removed py27, added py37
 # Pylint 2.4 / astroid 2.3 removed py34
+# Pylint 2.6.1 has issue https://github.com/PyCQA/pylint/issues/4096;
+#   the circumvention is to exclude pylint 2.6.1 and astroid 2.5.0 for now.
+#   TODO: After Pylint is fixed, double check whether astroid 2.5.0 still needs
+#         to be excluded.
 pylint>=1.6.4,<2.0.0; python_version == '2.7'
 pylint>=2.2.2,<2.4; python_version == '3.4'
-pylint>=2.5.0; python_version >= '3.5'
+pylint>=2.5.0,!=2.6.1; python_version >= '3.5'
 astroid>=1.4.9,<2.0.0; python_version == '2.7'
 astroid>=2.1.0,<2.3; python_version == '3.4'
-astroid>=2.4.0; python_version >= '3.5'
+astroid>=2.4.0,!=2.5.0; python_version >= '3.5'
 # typed-ast 1.4.0 removed support for Python 3.4.
 typed-ast>=1.3.0,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
 typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'


### PR DESCRIPTION
See commit message.
No review needed.