### PR TITLE
Circumvented an install failure of lazy-object-proxy on py35/minimum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,9 +430,15 @@ else
 ifeq ($(python_mn_version),3.4)
 	@echo "Makefile: Warning: Skipping Pylint on Python $(python_version)" >&2
 else
+ifeq ($(python_mn_version),3.5)
+	@echo "Makefile: Warning: Skipping Pylint on Python $(python_version)" >&2
+else
+	@echo "Makefile: Running Pylint"
 	-$(call RM_FUNC,$@)
 	pylint $(pylint_opts) --rcfile=$(pylint_rc_file) --output-format=text $(check_py_files)
 	echo "done" >$@
+	@echo "Makefile: Done running Pylint"
+endif
 endif
 endif
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -61,15 +61,28 @@ readme-renderer>=25.0; python_version >= '3.5'
 # Pylint 1.x / astroid 1.x supports py27 and py34/35/36
 # Pylint 2.0 / astroid 2.0 removed py27, added py37
 # Pylint 2.4 / astroid 2.3 removed py34
+# Workaround: lazy-object-proxy fails installing on macos/py35/minimum, because it uses
+#   setuptools-scm for its setup and (up to 1.5.2) does not correctly pin setuptools-scm.
+#   Not clear why this does not happen on ubuntu/windows with py35 or on py34.
+#   See issue https://github.com/ionelmc/python-lazy-object-proxy/issues/51.
+#   Working around this by not installing pylint/astroid on py35.
+#   TODO: If lazy-object-proxy releases a correctly pinned 1.4.x version, this workaround
+#         can be removed again.
 pylint>=1.6.4,<2.0.0; python_version == '2.7'
 pylint>=2.2.2,<2.4; python_version == '3.4'
-pylint>=2.5.0; python_version >= '3.5'
+pylint>=2.5.0; python_version >= '3.6'
 astroid>=1.4.9,<2.0.0; python_version == '2.7'
 astroid>=2.1.0,<2.3; python_version == '3.4'
-astroid>=2.4.0; python_version >= '3.5'
+astroid>=2.4.0; python_version >= '3.6'
+# typed-ast is used by astroid on py34..py37
 # typed-ast 1.4.0 removed support for Python 3.4.
 typed-ast>=1.3.0,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
-typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
+typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
+# Workaround: lazy-object-proxy is used by astroid, and lazy-object-proxy 1.5.0
+#   dropped support for py34 but declared it as supported
+lazy-object-proxy>=1.4.3; python_version == '2.7'
+lazy-object-proxy>=1.4.3,<1.5.0; python_version == '3.4'
+lazy-object-proxy>=1.4.3; python_version >= '3.6'
 
 # Flake8 (no imports, invoked via flake8 script):
 
@@ -120,7 +133,6 @@ pip-check-reqs>=2.0.4; python_version >= '3.4'
 # isort # MIT, from pylint
 # Jinja2 # BSD, from Sphinx
 # keyring # TBD
-# lazy-object-proxy # BSD, from astroid
 # MarkupSafe # BSD, from Jinja2 -> Sphinx
 # more-itertools # TBD
 # packaging # TBD

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -119,12 +119,17 @@ readme-renderer==25.0; python_version >= '3.5'
 # PyLint (no imports, invoked via pylint script) - does not support py3:
 pylint==1.6.4; python_version == '2.7'
 pylint==2.2.2; python_version == '3.4'
-pylint==2.5.0; python_version >= '3.5'
+pylint==2.5.0; python_version >= '3.6'
 astroid==1.4.9; python_version == '2.7'
 astroid==2.1.0; python_version == '3.4'
-astroid==2.4.0; python_version >= '3.5'
+astroid==2.4.0; python_version >= '3.6'
+# typed-ast is used by astroid on py34..py37
 typed-ast==1.3.0; python_version == '3.4' and implementation_name=='cpython'
-typed-ast==1.4.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
+typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
+# Workaround: lazy-object-proxy is used by astroid
+lazy-object-proxy==1.4.3; python_version == '2.7'
+lazy-object-proxy==1.4.3; python_version == '3.4'
+lazy-object-proxy==1.4.3; python_version >= '3.6'
 
 # Flake8 (no imports, invoked via flake8 script):
 flake8==3.8.0
@@ -170,7 +175,6 @@ iniconfig==1.1.1; python_version >= "3.6"  # used by pytest since its 6.0.0 whic
 isort==4.2.5
 Jinja2==2.8
 keyring==18.0.0
-lazy-object-proxy==1.2.2
 MarkupSafe==0.23
 mccabe==0.5.3
 more-itertools==5.0.0


### PR DESCRIPTION
See commit message.
No review needed.