### PR TITLE
Added support for validating HMC server certificates

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -75,5 +75,8 @@ Bibliography
    HMC Operations Guide 2.13.1
        `IBM z Systems Hardware Management Console Operations Guide (Version 2.13.1) <https://www-01.ibm.com/support/docview.wss?uid=isg20351070eb1b67cd985257f7000487d13>`_
 
+   HMC Security
+       `Hardware Management Console Security <https://www.ibm.com/support/pages/node/6017320>`_
+
    KVM for IBM z Systems V1.1.2 System Administration
        `IBM SC27-8237, KVM for IBM z Systems V1.1.2 System Administration <https://www.ibm.com/support/knowledgecenter/SSNW54_1.1.2/com.ibm.kvm.v112.kvmlp/KVM.htm>`_

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,11 +28,23 @@ Released: not yet
 
 **Incompatible changes:**
 
+* The zhmc command now verifies HMC server certificates by default, using the
+  CA certificates in the 'certifi' Python package. This verification will reject
+  the self-signed certificates the HMC is set up with initially. To deal with
+  this, install a CA-verifiable certificate in the HMC and specify the correct
+  CA certificates with the new '-c / --ca-certs' option. As a temporary quick
+  fix, you can disable the verification with the new '-n / --no-verify'
+  option.
+
 **Deprecations:**
 
 **Bug fixes:**
 
 **Enhancements:**
+
+* The zhmc command now supports verification of the HMC server certificate.
+  There are two new command line options '-n / --no-verify' and '-c / --ca-certs'
+  that control the verification behavior.
 
 **Cleanup:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -59,7 +59,8 @@ wheel==0.29.0
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
 
-zhmcclient==0.30.0
+# TODO: Enable 0.31.0 again before releasing
+# zhmcclient==0.31.0
 
 click==7.0
 click-repl==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,9 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-# git+https://github.com/zhmcclient/python-zhmcclient.git@master#egg=zhmcclient
-zhmcclient>=0.30.0 # Apache
+# TODO: Enable 0.31.0 again before releasing
+git+https://github.com/zhmcclient/python-zhmcclient.git@master#egg=zhmcclient
+# zhmcclient>=0.31.0 # Apache
 
 # click <7.0 did not properly declare supported Python versions
 # click 7.0 dropped support for Python 3.4, but still installs on it and works fine

--- a/zhmccli/_cmd_session.py
+++ b/zhmccli/_cmd_session.py
@@ -75,9 +75,28 @@ def cmd_session_create(cmd_ctx):
         raise click_exception(exc, cmd_ctx.error_format)
 
     cmd_ctx.spinner.stop()
+
+    if session.verify_cert is False:
+        no_verify = 'TRUE'
+        ca_certs = None
+    elif session.verify_cert is True:
+        no_verify = None
+        ca_certs = None
+    else:
+        no_verify = None
+        ca_certs = session.verify_cert
+
     click.echo("export ZHMC_HOST={h}".format(h=session.host))
     click.echo("export ZHMC_USERID={u}".format(u=session.userid))
     click.echo("export ZHMC_SESSION_ID={s}".format(s=session.session_id))
+    if no_verify is None:
+        click.echo("unset ZHMC_NO_VERIFY")
+    else:
+        click.echo("export ZHMC_NO_VERIFY={nv}".format(nv=no_verify))
+    if ca_certs is None:
+        click.echo("unset ZHMC_CA_CERTS")
+    else:
+        click.echo("export ZHMC_CA_CERTS={cc}".format(cc=ca_certs))
 
 
 def cmd_session_delete(cmd_ctx):


### PR DESCRIPTION
See commit message.
Will require zhmcclient 0.31, currently from its master branch.