### PR TITLE
0.21: Pinned zhmcclient version to <0.31

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,17 @@ Released: not yet
 
 **Bug fixes:**
 
+* Pinned zhmcclient version to <0.31 for two reasons:
+
+  - zhmcclient 0.31.0 introduces a new Session parameter 'verify_cert' that by
+    default verifies HMC certificates, so self-signed HMC certificates will fail.
+    zhmccli version 0.22 introduces the support for this new parameter, but
+    version 0.21 does not have that yet.
+
+  - zhmcclient 0.31.0 introduces that the properties attribute of resource
+    objects are immutable. zhmccli needs to accomodate that, and that support
+    is also in zhmccli version 0.22, but version 0.21 does not have that yet.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # Direct dependencies (except pip, setuptools, wheel):
 
 # git+https://github.com/zhmcclient/python-zhmcclient.git@master#egg=zhmcclient
-zhmcclient>=0.30.0 # Apache
+zhmcclient>=0.30.0,<0.31.0 # Apache
 
 # click <7.0 did not properly declare supported Python versions
 # click 7.0 dropped support for Python 3.4, but still installs on it and works fine


### PR DESCRIPTION
See commit message.
Set to priority because a release with that fix should be made very quickly.