### PR TITLE
1.0: Ignored Pylint issue 'consider-using-f-string' in new Pylint 2.11

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -73,7 +73,7 @@ disable=I0011, bad-option-value,
         wildcard-import, unused-wildcard-import,
         locally-enabled, superfluous-parens,
         super-with-arguments, useless-object-inheritance, raise-missing-from,
-        use-a-generator, redundant-u-string-prefix
+        use-a-generator, redundant-u-string-prefix, consider-using-f-string
 
 # Note: The too-many-* messages are excluded temporarily, and should be dealt
 #       with at some point.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,9 @@ Released: not yet
 
 * Fixed new issues reported by Pylint 2.10.
 
+* Disabled new Pylint issue 'consider-using-f-string', since f-strings were
+  introduced only in Python 3.6.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -920,8 +920,7 @@ def part_console(session, part, refresh, logger):
                 if topic_dict['topic-type'] != 'os-message-notification':
                     continue
                 obj_uri = topic_dict['object-uri']
-                if obj_uri == part.uri \
-                        or '/api/partitions/' + obj_uri == part.uri:
+                if part.uri in (obj_uri, '/api/partitions/' + obj_uri):
                     topic = topic_dict['topic-name']
                     console_log(logger, prefix,
                                 "Using existing notification topic: %s "


### PR DESCRIPTION
Rolls back PR #230 into 1.0.2.