### PR TITLE
Fixed >= constraint in minimum-constraints.txt for Pygments

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -169,8 +169,8 @@ smmap2==2.0.1
 smmap==3.0.1; python_version >= '3.5'
 sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.1.2
-Pygments>=2.1.3; python_version == '2.7'
-Pygments>=2.5.1; python_version >= '3.5'
+Pygments==2.1.3; python_version == '2.7'
+Pygments==2.5.1; python_version >= '3.5'
 sphinx-rtd-theme==0.5.0
 autodocsumm==0.1.13; python_version <= '3.9'
 autodocsumm==0.2.5; python_version >= '3.10'


### PR DESCRIPTION
No review needed.