### PR TITLE
Support for TESTOPTS containing blanks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ check_py_files := \
     $(test_py_files) \
 
 ifdef TESTCASES
-  pytest_opts := $(TESTOPTS) -k $(TESTCASES)
+  pytest_opts := $(TESTOPTS) -k "$(TESTCASES)"
 else
   pytest_opts := $(TESTOPTS)
 endif


### PR DESCRIPTION
No review needed.