### PR TITLE
Fixed type of --disk-partition-id option in "lpar scsi-load/scsi-dump"

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed that the "lpar scsi-load" and "lpar scsi-dump" commands defined their
+  --disk-partition-id option value incorrectly as a string, when it should have
+  been an integer. (issue #270)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -338,7 +338,7 @@ def lpar_psw_restart(cmd_ctx, cpc, lpar, **options):
 @click.option('--load-parameter', type=str, required=False,
               help='Provides additional control over the outcome of a '
               'Load operation. Default: empty')
-@click.option('--disk-partition-id', type=str, required=False,
+@click.option('--disk-partition-id', type=int, required=False,
               help='Provides boot program selector. Default: 0')
 @click.option('--operating-system-specific-load-parameters', type=str,
               required=False, help='Provides specific load parameters. '
@@ -382,7 +382,7 @@ def lpar_scsi_load(cmd_ctx, cpc, lpar, load_address, wwpn, lun, **options):
 @click.option('--load-parameter', type=str, required=False,
               help='Provides additional control over the outcome of a '
               'Load operation. Default: empty')
-@click.option('--disk-partition-id', type=str, required=False,
+@click.option('--disk-partition-id', type=int, required=False,
               help='Provides boot program selector. Default: 0')
 @click.option('--operating-system-specific-load-parameters', type=str,
               required=False, help='Provides specific load parameters. '


### PR DESCRIPTION
For details, see the commit message.