### PR TITLE
Fixed that "lpar list --names-only" had an empty "cpc" column

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,8 @@ Released: not yet
   --disk-partition-id option value incorrectly as a string, when it should have
   been an integer. (issue #270)
 
+* Fixed that "lpar list --names-only" had an empty "cpc" column. (issue #269)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -477,7 +477,8 @@ def cmd_lpar_list(cmd_ctx, cpc_name, options):
         ])
 
     for lpar in lpars:
-        additions['cpc'][lpar.uri] = cpc_name
+        cpc = lpar.manager.parent
+        additions['cpc'][lpar.uri] = cpc.name
 
     try:
         print_resources(cmd_ctx, lpars, cmd_ctx.output_format, show_list,


### PR DESCRIPTION
I tested manually that "lpar list --names-only" now shows the CPC names.
I double checked that the same error does not also exist for "partition list --names-only".