### PR TITLE
Adjusted testcases to new error format of zhmcclient 1.3.3

### DIFF
--- a/tests/function/test_info.py
+++ b/tests/function/test_info.py
@@ -295,13 +295,13 @@ class TestInfo(object):
         "err_format, exp_stderr_patterns", [
             (None,  # default format: msg
              [r"Error: ConnectionError: "
-              r"Failed to establish a new connection:[^']+"]),
+              r".*Failed to establish a new connection:.*"]),
             ('msg',
              [r"Error: ConnectionError: "
-              r"Failed to establish a new connection:[^']+"]),
+              r".*Failed to establish a new connection:.*"]),
             ('def',
              [r"Error: classname='ConnectionError'; "
-              r"message='Failed to establish a new connection:[^']+';"]),
+              r"message=['\"].*Failed to establish a new connection:.*['\"];"]),
         ]
     )
     @pytest.mark.parametrize(


### PR DESCRIPTION
No review needed. Testes with both zhmcclient 1.3.2 and 1.3.3.