### PR TITLE
1.2: Fixed a flake8 AttributeError by pinning importlib-metadata

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,6 +19,8 @@ pytest>=4.3.1,<5.0.0; python_version == '2.7'
 pytest>=4.3.1; python_version >= '3.5' and python_version <= '3.6'
 pytest>=4.4.0; python_version >= '3.7' and python_version <= '3.9'
 pytest>=6.2.5; python_version >= '3.10'
+importlib-metadata>=0.12,<5.0.0; python_version <= '3.7'
+importlib-metadata>=1.1.0; python_version >= '3.8'
 
 # colorama 0.4.3 has removed support for Python < 3.5
 colorama>=0.4.0; sys_platform == "win32" and python_version == "2.7"
@@ -143,7 +145,6 @@ pip-check-reqs>=2.0.4; python_version >= '3.5'
 # gitdb2 # BSD, from GitPython
 # gitdb # BSD, from GitPython
 # imagesize # MIT, from Sphinx
-# importlib-metadata # TBD
 # isort # MIT, from pylint
 # Jinja2 # BSD, from Sphinx
 # keyring # TBD

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed a flake8 AttributeError when using importlib-metadata 5.0.0 on
+  Python >=3.7, by pinning importlib-metadata to <5.0.0 on these Python
+  versions.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -148,6 +148,8 @@ wcwidth==0.1.7
 pytest==4.3.1; python_version <= '3.6'
 pytest==4.4.0; python_version >= '3.7' and python_version <= '3.9'
 pytest==6.2.5; python_version >= '3.10'
+importlib-metadata==0.12; python_version <= '3.7'
+importlib-metadata==1.1.0; python_version >= '3.8'
 
 # Coverage reporting (no imports, invoked via coveralls script):
 coverage==5.0
@@ -237,7 +239,6 @@ enum34==1.1.6; python_version == "2.7"
 funcsigs==1.0.2; python_version == "2.7"
 futures==3.3.0; python_version == "2.7"
 imagesize==0.7.1
-importlib-metadata==0.12; python_version <= '3.7'
 iniconfig==1.1.1; python_version >= "3.6"  # used by pytest since its 6.0.0 which requires py36
 isort==4.3.5
 Jinja2==2.8; python_version <= '3.9'


### PR DESCRIPTION
Rolls back PR #299 into 1.2.2.