### PR TITLE
1.2: Defined and used constants for API versions of new HMC versions

### DIFF
--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -26,7 +26,7 @@ from .zhmccli import cli, CONSOLE_LOGGER_NAME
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     part_console, click_exception, add_options, LIST_OPTIONS, TABLE_FORMATS, \
-    hide_property, ASYNC_TIMEOUT_OPTIONS
+    hide_property, ASYNC_TIMEOUT_OPTIONS, API_VERSION_HMC_2_14_0
 from ._cmd_cpc import find_cpc
 
 
@@ -39,7 +39,7 @@ def find_lpar(cmd_ctx, client, cpc_or_name, lpar_name):
     else:
         cpc_name = cpc_or_name
 
-    if client.version_info() >= (2, 20):  # Starting with HMC 2.14.0
+    if client.version_info() >= API_VERSION_HMC_2_14_0:
         # This approach is faster than going through the CPC.
         # In addition, starting with HMC API version 3.6 (an update to
         # HMC 2.15.0), this approach supports users that do not have object
@@ -425,7 +425,7 @@ def cmd_lpar_list(cmd_ctx, cpc_name, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
 
-    if client.version_info() >= (2, 20):  # Starting with HMC 2.14.0
+    if client.version_info() >= API_VERSION_HMC_2_14_0:
         # This approach is faster than going through the CPC.
         # In addition, starting with HMC API version 3.6 (an update to
         # HMC 2.15.0), this approach supports users that do not have object

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -31,7 +31,7 @@ from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     part_console, click_exception, storage_management_feature, \
     add_options, LIST_OPTIONS, TABLE_FORMATS, hide_property, \
-    ASYNC_TIMEOUT_OPTIONS
+    ASYNC_TIMEOUT_OPTIONS, API_VERSION_HMC_2_14_0
 from ._cmd_cpc import find_cpc
 from ._cmd_storagegroup import find_storagegroup
 from ._cmd_metrics import get_metric_values
@@ -59,7 +59,7 @@ def find_partition(cmd_ctx, client, cpc_or_name, partition_name):
     else:
         cpc_name = cpc_or_name
 
-    if client.version_info() >= (2, 20):  # Starting with HMC 2.14.0
+    if client.version_info() >= API_VERSION_HMC_2_14_0:
         # This approach is faster than going through the CPC.
         # In addition, this approach supports users that do not have object
         # access permission to the parent CPC of the LPAR.
@@ -734,7 +734,7 @@ Help for usage related options of the partition list command:
 
     client = zhmcclient.Client(cmd_ctx.session)
 
-    if client.version_info() >= (2, 20):  # Starting with HMC 2.14.0
+    if client.version_info() >= API_VERSION_HMC_2_14_0:
         # This approach is faster than going through the CPC.
         # In addition, this approach supports users that do not have object
         # access permission to the parent CPC of the LPAR.

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -32,6 +32,18 @@ from tabulate import tabulate
 import zhmcclient
 import zhmcclient_mock
 
+# HMC API versions for new HMC versions
+# Can be used for comparison with Client.version_info()
+API_VERSION_HMC_2_11_1 = (1, 1)
+API_VERSION_HMC_2_12_0 = (1, 3)
+API_VERSION_HMC_2_12_1 = (1, 4)
+API_VERSION_HMC_2_13_0 = (1, 6)
+API_VERSION_HMC_2_13_1 = (1, 7)
+API_VERSION_HMC_2_14_0 = (2, 20)
+API_VERSION_HMC_2_14_1 = (2, 35)
+API_VERSION_HMC_2_15_0 = (3, 1)
+API_VERSION_HMC_2_16_0 = (4, 1)
+
 # Display of options in usage line
 GENERAL_OPTIONS_METAVAR = '[GENERAL-OPTIONS]'
 COMMAND_OPTIONS_METAVAR = '[COMMAND-OPTIONS]'


### PR DESCRIPTION
Rolls back PR #301 into 1.2.2.