### PR TITLE
1.2: Fixed --boot-iso option of 'partition update' command

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,10 @@ Released: not yet
   Python >=3.7, by pinning importlib-metadata to <5.0.0 on these Python
   versions.
 
+* Fixed that the --boot-iso option of the 'partition update' command took a
+  TEXT argument (which was not used). Changed that to a flag option.
+  (issue #287)
+
 * Fixed that 'user create' passed the 'mfa-types' and
   'multi-factor-authentication-required' properties to the HMC even when no
   MFA-related options were specified. This caused rejection of the command on

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -442,8 +442,9 @@ def partition_create(cmd_ctx, cpc, **options):
 @click.option('--boot-media-file', type=str, required=False,
               help='Boot from removable media on the HMC: The path to the '
               'image file on the HMC.')
-@click.option('--boot-iso', type=str, required=False,
-              help='Boot from an ISO image mounted to this partition.')
+@click.option('--boot-iso', is_flag=True, required=False,
+              help='Boot from an ISO image mounted to this partition. '
+              'The ISO image can be mounted using "zhmc partition mountiso".')
 @click.option('--secure-boot', type=bool, required=False,
               help='Check the software signature of what is booted against '
               'what the distributor signed it with. '
@@ -1243,7 +1244,11 @@ def cmd_partition_update(cmd_ctx, cpc_name, partition_name, options):
 
     elif used_boot_iso_opts:
         properties['boot-device'] = 'iso-image'
-
+        # Note: 'boot-iso-image-name' is read-only and is changed by using
+        #       the Mount/Unmount ISO operations.
+        # Note: 'boot-iso-ins-file' is writeable, for using a different
+        #       INS file than the one specified in Mount ISO. This is not
+        #       currently supported by zhmccli.
     else:
         # boot-device="none" is the default
         pass


### PR DESCRIPTION
Rolls back PR #305 into 1.2.2.