### PR TITLE
1.2: Fixed incorrect detection of --boot-iso option in partition update

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed a mistake in the previous fix of the --boot-iso option of the
+  'partition update' command. (related to issue #287)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -1150,7 +1150,7 @@ def cmd_partition_update(cmd_ctx, cpc_name, partition_name, options):
 
     used_boot_iso_opts = [
         '--' + name for name in boot_iso_option_names
-        if org_options[name] is not None]
+        if org_options[name]]  # is_flag options default to False
 
     if used_boot_storage_opts and used_old_boot_storage_opts:
         raise click_exception(


### PR DESCRIPTION
Rolls back PR #311 into 1.2.3.