### PR TITLE
Docs: Added a section 'Setting up firewalls or proxies'

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,9 @@ Released: not yet
 * Simplified release process by adding a new GitHub Actions workflow publish.yml
   to build and publish to PyPI.
 
+* Docs: Added a section "Setting up firewalls or proxies" that provides
+  information which ports to open for accessing the HMC. (issue #335)
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -202,6 +202,21 @@ section "Enabling the System z HMC to work the Pacemaker STONITH Agent", in the
 :term:`KVM for IBM z Systems V1.1.2 System Administration` book.
 
 
+.. _`Setting up firewalls or proxies`:
+
+Setting up firewalls or proxies
+-------------------------------
+
+If you have to configure firewalls or proxies between the client system and
+the HMC, the following ports need to be opened:
+
+* 6794 (TCP) - for the HMC API HTTP server
+* 61612 (TCP) - for the HMC API message broker via JMS over STOMP
+
+For details, see sections "Connecting to the API HTTP server" and
+"Connecting to the API message broker" in the :term:`HMC API` book.
+
+
 .. _`Examples`:
 
 Examples


### PR DESCRIPTION
No review needed, since it is the same text as in PR https://github.com/zhmcclient/python-zhmcclient/pull/1093.