### PR TITLE
1.4: Unpinned Click from <8 for py>=3.6

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -40,6 +40,8 @@ Released: not yet
 
 **Cleanup:**
 
+* Unpinned Click from <8 for Python >=3.6 (issue #331)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -101,7 +101,8 @@ wheel==0.33.5; python_version >= '3.8'
 zhmcclient==1.5.0
 
 click==7.0
-click-repl==0.1.0
+click-repl==0.1.6; python_version <= '3.5'
+click-repl==0.2; python_version >= '3.6'
 click-spinner==0.1.6
 progressbar2==3.12.0
 # virtualenv 20.0 requires six>=1.12.0 on py>=3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,13 +13,12 @@
 zhmcclient>=1.5.0  # Apache
 
 # click <7.0 did not properly declare supported Python versions
-# click 8.0 will drop support for Python 2.7,3.5
-# click 8.0 is incompatible with click-repl.
-click>=7.0,<8.0; python_version == '2.7'  # BSD
-click>=7.0,<8.0; python_version == '3.5'  # BSD
-click>=7.0,<8.0; python_version >= '3.6'  # BSD
-
-click-repl>=0.1.0 # MIT
+# click 8.0 has dropped support for Python 2.7,3.5
+click>=7.0,<8.0; python_version <= '3.5'
+click>=7.0; python_version >= '3.6'
+# click-repl 0.2 is needed for compatibility with Click 8.0 (see issue #819 click-repl incompatible)
+click-repl>=0.1.6; python_version <= '3.5'
+click-repl>=0.2; python_version >= '3.6'
 click-spinner>=0.1.6 # MIT
 progressbar2>=3.12.0 # BSD
 six>=1.14.0; python_version <= '3.9' # MIT


### PR DESCRIPTION
Rolls back PR #344 into 1.4.1.