### PR TITLE
Fixed tomli dependency for Python 3.6

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -311,7 +311,9 @@ sphinxcontrib-jsmath==1.0.0; python_version >= '3.5'
 sphinxcontrib-qthelp==1.0.0; python_version >= '3.5'
 sphinxcontrib-serializinghtml==1.1.5; python_version >= '3.5'
 toml==0.10.0  # used by pylint and pytest since some version
-tomli==2.0.1; python_version >= '3.5'
+# tomli 2.0.0 removed support for py36
+tomli==1.1.0; python_version == '3.6'
+tomli==2.0.1; python_version >= '3.7'
 tomlkit==0.10.1; python_version >= '3.7'
 tqdm==4.28.1
 typing==3.6.1


### PR DESCRIPTION
No review needed.