### PR TITLE
1.5: Fixed TypeError with cpc dpm-export/import commands and Click 8

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -35,6 +35,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed TypeError exception in Click package when using 'cpc dpm-export' or
+  'cpc dpm-import' commands. (issue #370)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/tests/function/test_cpc_dpmexport_opts.py
+++ b/tests/function/test_cpc_dpmexport_opts.py
@@ -1,0 +1,47 @@
+# Copyright 2023 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function tests for options of 'zhmc cpc dpm-export' command.
+"""
+
+from __future__ import absolute_import, print_function
+
+from .utils import call_zhmc_child, assert_rc
+
+
+def test_cpc_dpmexport_help():
+    """Test 'zhmc cpc dpm-export --help'"""
+
+    rc, stdout, stderr = call_zhmc_child(
+        ['cpc', 'dpm-export', '--help'])
+
+    assert_rc(0, rc, stdout, stderr)
+    assert stdout.startswith(
+        "Usage: zhmc cpc dpm-export [COMMAND-OPTIONS] CPC\n"), \
+        "stdout={s!r}".format(s=stdout)
+    assert stderr == ""
+
+
+def test_cpc_dpmexport_helpdpmfile():
+    """Test 'zhmc cpc dpm-export --help-dpm-file'"""
+
+    rc, stdout, stderr = call_zhmc_child(
+        ['cpc', 'dpm-export', '--help-dpm-file'])
+
+    assert_rc(0, rc, stdout, stderr)
+    assert stdout.startswith(
+        "\nFormat of DPM configuration file:\n"), \
+        "stdout={s!r}".format(s=stdout)
+    assert stderr == ""

--- a/tests/function/test_cpc_dpmimport_opts.py
+++ b/tests/function/test_cpc_dpmimport_opts.py
@@ -1,0 +1,60 @@
+# Copyright 2023 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Function tests for options of 'zhmc cpc dpm-import' command.
+"""
+
+from __future__ import absolute_import, print_function
+
+from .utils import call_zhmc_child, assert_rc
+
+
+def test_cpc_dpmimport_help():
+    """Test 'zhmc cpc dpm-import --help'"""
+
+    rc, stdout, stderr = call_zhmc_child(
+        ['cpc', 'dpm-import', '--help'])
+
+    assert_rc(0, rc, stdout, stderr)
+    assert stdout.startswith(
+        "Usage: zhmc cpc dpm-import [COMMAND-OPTIONS] CPC\n"), \
+        "stdout={s!r}".format(s=stdout)
+    assert stderr == ""
+
+
+def test_cpc_dpmimport_helpdpmfile():
+    """Test 'zhmc cpc dpm-import --help-dpm-file'"""
+
+    rc, stdout, stderr = call_zhmc_child(
+        ['cpc', 'dpm-import', '--help-dpm-file'])
+
+    assert_rc(0, rc, stdout, stderr)
+    assert stdout.startswith(
+        "\nFormat of DPM configuration file:\n"), \
+        "stdout={s!r}".format(s=stdout)
+    assert stderr == ""
+
+
+def test_cpc_dpmimport_helpmappingfile():
+    """Test 'zhmc cpc dpm-import --help-mapping-file'"""
+
+    rc, stdout, stderr = call_zhmc_child(
+        ['cpc', 'dpm-import', '--help-mapping-file'])
+
+    assert_rc(0, rc, stdout, stderr)
+    assert stdout.startswith(
+        "\nFormat of adapter mapping file:\n"), \
+        "stdout={s!r}".format(s=stdout)
+    assert stderr == ""

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -82,7 +82,8 @@ MAPPING_SCHEMA = {
 }
 
 
-def help_dpm_file(cmd_ctx, value):
+def help_dpm_file(cmd_ctx, param, value):
+    # pylint: disable=unused-argument
     """
     Click callback function for --help-dpm-file option, that displays
     help for the format of the DPM configuration file and exits.
@@ -118,7 +119,8 @@ corresponding options when issuing the 'Import DPM Configuration' operation.
     cmd_ctx.exit()
 
 
-def help_mapping_file(cmd_ctx, value):
+def help_mapping_file(cmd_ctx, param, value):
+    # pylint: disable=unused-argument
     """
     Click callback function for --help-dpm-file option, that displays
     help for the format of the adapter mapping file and exits.


### PR DESCRIPTION
Rolls back PR #371 into 1.5.1.
No review needed.