### PR TITLE
Support for unmanaged CPCs

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -63,6 +63,8 @@ Released: not yet
 
 * Added support for Python 3.11.
 
+* Added 'zhmc unmanaged_cpc' command group for dealing with unmanaged CPCs.
+
 **Cleanup:**
 
 * Increased minimum versions of pip, setuptools, wheel to more recent versions.

--- a/zhmccli/__init__.py
+++ b/zhmccli/__init__.py
@@ -23,6 +23,7 @@ from ._cmd_info import *       # noqa: F401
 from ._cmd_session import *    # noqa: F401
 from ._cmd_console import *    # noqa: F401
 from ._cmd_cpc import *        # noqa: F401
+from ._cmd_unmanaged_cpc import *  # noqa: F401
 from ._cmd_lpar import *       # noqa: F401
 from ._cmd_partition import *  # noqa: F401
 from ._cmd_adapter import *    # noqa: F401

--- a/zhmccli/_cmd_unmanaged_cpc.py
+++ b/zhmccli/_cmd_unmanaged_cpc.py
@@ -1,0 +1,88 @@
+# Copyright 2023 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Commands for unmanaged CPCs.
+"""
+
+from __future__ import absolute_import
+
+import click
+
+import zhmcclient
+from .zhmccli import cli
+from ._helper import print_resources, click_exception, COMMAND_OPTIONS_METAVAR
+
+
+def find_unmanaged_cpc(cmd_ctx, console, cpc_name):
+    """
+    Find an unmanaged CPC by name and return its resource object.
+    """
+    try:
+        ucpc = console.unmanaged_cpcs.find(name=cpc_name)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+    return ucpc
+
+
+@cli.group('unmanaged_cpc', options_metavar=COMMAND_OPTIONS_METAVAR)
+def ucpc_group():
+    """
+    Command group for unmanaged CPCs.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+
+
+@ucpc_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.option('--uri', is_flag=True, required=False,
+              help='Add the resource URI to the properties shown')
+@click.pass_obj
+def ucpc_list(cmd_ctx, **options):
+    """
+    List the unmanaged CPCs of the HMC.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_ucpc_list(cmd_ctx, options))
+
+
+def cmd_ucpc_list(cmd_ctx, options):
+    # pylint: disable=missing-function-docstring
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    console = client.consoles.console
+
+    try:
+        ucpcs = console.unmanaged_cpcs.list()
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    show_list = [
+        'name',
+    ]
+    if options['uri']:
+        show_list.extend([
+            'object-uri',
+        ])
+
+    try:
+        print_resources(cmd_ctx, ucpcs, cmd_ctx.output_format, show_list,
+                        all=False)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)


### PR DESCRIPTION
The main review point I think would be how the unmanaged CPCs are surfaced by the cli:

This PR introduces a new command group with a single command:
```
zhmc unmanaged_cpc list
```

The original proposal in issue #98 was to add the list command to the console command group:
```
zhmc console list-unmanaged-cpcs
```