### PR TITLE
Support for changing crypto type and FICON type of adapters; Removed --crypto-number

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,9 +41,17 @@ Released: not yet
 * Fixed the incorrect representation of string values as floating point numbers
   in the table output formats. (issue #391)
 
+* Removed the option '--crypto-number' from the 'zhmc adapter update' command.
+  This is not an incompatible change, since it is not possible to change the
+  the crypto number of a Crypto Express adapter. (part of issue #108)
+
 **Enhancements:**
 
 * Added 'zhmc unmanaged_cpc' command group for dealing with unmanaged CPCs.
+
+* Added support for changing the crypto type of Crypto Express adapters
+  and the type of FICON Express adapters to the 'zhmc adapter update'
+  command. (issue #108)
 
 * Added a troubleshooting section to the docs.
 


### PR DESCRIPTION
For details, see the commit message.

Note, this requires zhmcclient PR https://github.com/zhmcclient/python-zhmcclient/pull/1177, which is targeted for zhmcclient 1.8.0.