### PR TITLE
Added initial support for end2end tests

### DIFF
--- a/.coveragerc.end2end
+++ b/.coveragerc.end2end
@@ -1,0 +1,26 @@
+# Config file for Python "coverage" package.
+#
+# For documentation, see:
+# http://coverage.readthedocs.org/en/latest/config.html
+
+[run]
+
+# Controls whether branch coverage is measured, vs. just statement coverage.
+# TODO: Once statement coverage gets better, enable branch coverage.
+branch = False
+
+# If True, stores relative file paths in data file (needed for Github Actions).
+# Using this parameter requires coverage>=5.0
+relative_files = True
+
+# The following files are omitted in the coverage.
+omit =
+
+[report]
+
+# Controls whether lines without coverage are shown in the report.
+show_missing = True
+
+[html]
+
+directory = htmlcov.end2end

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.tox/
 /.pytest_cache/
 /htmlcov/
+/htmlcov.end2end/
 /build/
 /build_doc/
 /dist/

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -62,6 +62,10 @@ Released: not yet
 * Added 'zhmc ldap' command group for managing LDAP server definitions.
   (issue #393)
 
+* Added initial support for end2end tests. For details, see the new
+  "Running end2end tests" section in the documentation.
+  A first end2end testcase for the 'zhmc session' command has been added.
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -101,30 +101,111 @@ The top-level document to open with a web browser will be
 Testing
 -------
 
-To run unit tests in the currently active Python environment, issue one of
+There are two kinds of tests:
+
+* function tests: Function testcases run against a zhmcclient_mock environment.
+
+* end2end tests: End2end testcases run against an HMC or set of HMCs defined
+  in an HMC inventory file, with credentials from an HMC vault file.
+
+
+Running function tests
+^^^^^^^^^^^^^^^^^^^^^^
+
+To run the function tests in the currently active Python environment, issue one of
 these example variants of ``make test``:
 
 .. code-block:: text
 
-    $ make test                                  # Run all unit tests
-    $ TESTCASES=test_resource.py make test       # Run only this test source file
-    $ TESTCASES=TestInit make test               # Run only this test class
-    $ TESTCASES="TestInit or TestSet" make test  # py.test -k expressions are possible
+    $ make test                                  # Run all function tests
+    $ TESTCASES=test_info.py make test           # Run only this function test source file
+    $ TESTCASES=TestInfo make test               # Run only this function test class
+    $ TESTCASES="test_info_help or test_info_error_no_host" make test  # py.test -k expressions are possible
 
-To run the unit tests and some more commands that verify the project is in good
+To run the function tests and some more commands that verify the project is in good
 shape in all supported Python environments, use Tox:
 
 .. code-block:: text
 
-    $ tox                              # Run all tests on all supported Python versions
-    $ tox -e py27                      # Run all tests on Python 2.7
-    $ tox -e py27 test_resource.py     # Run only this test source file on Python 2.7
-    $ tox -e py27 TestInit             # Run only this test class on Python 2.7
-    $ tox -e py27 TestInit or TestSet  # py.test -k expressions are possible
+    $ tox                              # Run all function tests on all supported Python versions
+    $ tox -e py39                      # Run all function tests on Python 3.9
+    $ tox -e py39 test_info.py         # Run only this function test source file on Python 3.9
+    $ tox -e py39 TestInfo             # Run only this function test class on Python 3.9
+    $ tox -e py39 test_info_help or test_info_error_no_host  # py.test -k expressions are possible
 
 The positional arguments of the ``tox`` command are passed to ``py.test`` using
 its ``-k`` option. Invoke ``py.test --help`` for details on the expression
 syntax of its ``-k`` option.
+
+
+Running end2end tests
+^^^^^^^^^^^^^^^^^^^^^
+
+To run the end2end tests in the currently active Python environment, you first
+need to prepare an `HMC inventory file`_ that defines real and/or mocked HMCs
+the tests should be run against, and an `HMC vault file`_ with credentials for
+the real HMCs.
+
+There are examples for these files, that describe their format in the comment
+header:
+
+* `Example HMC inventory file`_.
+* `Example HMC vault file`_.
+
+To run the end2end tests in the currently active Python environment, issue:
+
+.. code-block:: text
+
+    $ make end2end
+
+By default, the HMC inventory file named ``.zhmc_inventory.yaml`` in the home
+directory of the current user is used. A different path name can be specified
+with the ``TESTINVENTORY`` environment variable.
+
+By default, the HMC vault file named ``.zhmc_vault.yaml`` in the home directory
+of the current user is used. A different path name can be specified with the
+``TESTVAULT`` environment variable.
+
+By default, the tests are run against the group name or HMC nickname
+``default`` defined in the HMC inventory file. A different group name or
+HMC nickname can be specified with the ``TESTHMC`` environment variable.
+
+To show the defined HMC nicknames and groups that can be used, issue:
+
+.. code-block:: text
+
+    $ make end2end_show
+
+Examples:
+
+* Run against group or HMC nickname 'default' using the default HMC inventory and
+  vault files:
+
+  .. code-block:: text
+
+      $ make end2end
+
+* Run against group or HMC nickname 'HMC1' using the default HMC inventory and
+  vault files:
+
+  .. code-block:: text
+
+      $ TESTHMC=HMC1 make end2end
+
+* Run against group or HMC nickname 'default' using the specified HMC inventory
+  and vault files:
+
+  .. code-block:: text
+
+      $ TESTINVENTORY=./hmc_inventory.yaml TESTVAULT=./hmc_vault.yaml make end2end
+
+In addition, the variables ``TESTCASES`` and ``TESTOPTS`` can be specified,
+as for function tests. Invoke ``make help`` for details.
+
+.. _HMC inventory file: https://python-zhmcclient.readthedocs.io/en/latest/development.html#hmc-inventory-file
+.. _HMC vault file: https://python-zhmcclient.readthedocs.io/en/latest/development.html#hmc-vault-file
+.. _Example HMC inventory file: https://github.com/zhmcclient/python-zhmcclient/blob/master/examples/example_hmc_inventory.yaml
+.. _Example HMC vault file: https://github.com/zhmcclient/python-zhmcclient/blob/master/examples/example_hmc_vault.yaml
 
 
 .. _`Contributing`:

--- a/tests/end2end/test_session.py
+++ b/tests/end2end/test_session.py
@@ -1,0 +1,142 @@
+# Copyright 2023 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End2end tests for the 'zhmc session' command group.
+"""
+
+from __future__ import absolute_import, print_function
+
+import os
+import re
+from requests.packages import urllib3
+
+# pylint: disable=line-too-long,unused-import
+from zhmcclient.testutils import hmc_definition  # noqa: F401, E501
+# pylint: enable=line-too-long,unused-import
+
+from .utils import zhmc_session_args, run_zhmc
+
+urllib3.disable_warnings()
+
+
+def test_session_success(hmc_definition):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Test successful creation and deletion of an HMC session.
+    """
+
+    # Create the session
+
+    # Set to True to debug 'zhmc session create'
+    pdb = False
+
+    zhmc_args = zhmc_session_args(hmc_definition) + ['session', 'create']
+
+    # The code to be tested
+    rc, stdout, stderr = run_zhmc(zhmc_args, pdb=pdb)
+
+    if not pdb:
+        assert rc == 0, \
+            "Unexpected exit code: {}\nstdout:\n{}\nstderr:\n{}". \
+            format(rc, stdout, stderr)
+        assert stderr == '', \
+            "Unexpected stderr:\n{}".format(stderr)
+
+        export_vars = {}
+        unset_vars = {}
+        for line in stdout.splitlines():
+            m = re.match(r'^unset (ZHMC_[A-Z_]+)$', line)
+            if m:
+                name = m.group(1)
+                unset_vars[name] = True
+                continue
+            m = re.match(r'^export (ZHMC_[A-Z_]+)=(.*)$', line)
+            if m:
+                name = m.group(1)
+                value = m.group(2)
+                export_vars[name] = value
+                continue
+            raise AssertionError("Unexpected line on stdout: {!r}".format(line))
+
+        assert 'ZHMC_HOST' in export_vars
+        zhmc_host = export_vars.pop('ZHMC_HOST')
+        assert zhmc_host == hmc_definition.host
+
+        assert 'ZHMC_USERID' in export_vars
+        zhmc_userid = export_vars.pop('ZHMC_USERID')
+        assert zhmc_userid == hmc_definition.userid
+
+        assert 'ZHMC_SESSION_ID' in export_vars
+        zhmc_session_id = export_vars.pop('ZHMC_SESSION_ID')
+
+        if hmc_definition.verify:
+            assert 'ZHMC_NO_VERIFY' in unset_vars
+            _ = unset_vars.pop('ZHMC_NO_VERIFY')
+        else:
+            assert 'ZHMC_NO_VERIFY' in export_vars
+            zhmc_no_verify = export_vars.pop('ZHMC_NO_VERIFY')
+            assert bool(zhmc_no_verify) is True
+
+        if hmc_definition.ca_certs is None:
+            assert 'ZHMC_CA_CERTS' in unset_vars
+            _ = unset_vars.pop('ZHMC_CA_CERTS')
+        else:
+            assert 'ZHMC_CA_CERTS' in export_vars
+            zhmc_ca_certs = export_vars.pop('ZHMC_CA_CERTS')
+            assert zhmc_ca_certs == hmc_definition.ca_certs
+
+        assert not export_vars
+        assert not unset_vars
+
+    # Delete the session
+
+    # Set to True to debug 'zhmc session delete'
+    pdb = False
+
+    zhmc_args = ['session', 'delete']
+
+    # Setup the environment is it was returned from session create
+    env = dict(os.environ)
+    env['ZHMC_SESSION_ID'] = zhmc_session_id
+    env['ZHMC_HOST'] = zhmc_host
+    env['ZHMC_USERID'] = zhmc_userid
+    if not hmc_definition.verify:
+        env['ZHMC_NO_VERIFY'] = zhmc_no_verify
+    if hmc_definition.ca_certs:
+        env['ZHMC_CA_CERTS'] = zhmc_ca_certs
+
+    # The code to be tested
+    rc, stdout, stderr = run_zhmc(zhmc_args, env=env, pdb=pdb)
+
+    if not pdb:
+        assert rc == 0, \
+            "Unexpected exit code: {}\nstdout:\n{}\nstderr:\n{}". \
+            format(rc, stdout, stderr)
+        assert stderr == '', \
+            "Unexpected stderr:\n{}".format(stderr)
+
+        unset_vars = {}
+        for line in stdout.splitlines():
+            m = re.match(r'^unset (ZHMC_[A-Z_]+)$', line)
+            if m:
+                name = m.group(1)
+                unset_vars[name] = True
+                continue
+            raise AssertionError("Unexpected line on stdout: {!r}".format(line))
+
+        assert 'ZHMC_SESSION_ID' in unset_vars
+        _ = unset_vars.pop('ZHMC_SESSION_ID')
+
+        assert not unset_vars

--- a/tests/end2end/utils.py
+++ b/tests/end2end/utils.py
@@ -1,0 +1,191 @@
+# Copyright 2023 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utility functions for end2end tests.
+"""
+
+from __future__ import absolute_import, print_function
+
+import os
+import re
+import subprocess
+import random
+import warnings
+import six
+import pytest
+
+# Prefix used for names of resources that are created during tests
+TEST_PREFIX = 'zhmcclient_tests_end2end'
+
+
+class End2endTestWarning(UserWarning):
+    """
+    Python warning indicating an issue with an end2end test.
+    """
+    pass
+
+
+def zhmc_session_args(hmc_definition):  # noqa: F811
+    # pylint: disable=redefined-outer-name
+    """
+    Return the session related command line options for zhmc from an HMC
+    definition.
+
+    Parameters:
+
+      hmc_definition(zhmcclient.testutils.HMCDefiniton): HMC definition.
+
+    Returns:
+      list of str: zhmc session related command line options.
+    """
+    ret = []
+    if not hmc_definition.verify:
+        ret.append('-n')
+    ret.extend(['-h', hmc_definition.host])
+    ret.extend(['-u', hmc_definition.userid])
+    ret.extend(['-p', hmc_definition.password])
+    if hmc_definition.ca_certs:
+        ret.extend(['-c', hmc_definition.ca_certs])
+    return ret
+
+
+def run_zhmc(args, env=None, pdb=False):
+    """
+    Run the zhmc command and return its exit code, stdout and stderr.
+
+    Parameters:
+
+      args(list/tuple of str): List of command line arguments, not including
+        the 'zhmc' command name itself.
+
+      env(dict of str/str): Environment variables to be used instead of the
+        current process' variables.
+
+      pdb(bool): If True, debug the zhmc command. This is done by inserting
+        the '--pdb' option to the command arguments, and by not capturing the
+        stdout/stderr.
+
+    Returns:
+      tuple (rc, stdout, stderr) as follows:
+      - rc(int): zhmc exit code
+      - stdout(str): stdout string, or None if debugging the zhmc command
+      - stderr(str): stderr string, or None if debugging the zhmc command
+    """
+    assert isinstance(args, (list, tuple))
+    if env is not None:
+        assert isinstance(env, dict)
+
+    p_args = ['zhmc'] + args
+
+    # Set up output capturing, dependent on pdb flag
+    if pdb:
+        kwargs = {}
+        p_args.insert(1, '--pdb')
+    else:
+        kwargs = {
+            'stdout': subprocess.PIPE,
+            'stderr': subprocess.PIPE,
+        }
+
+    # pylint: disable=consider-using-with
+    proc = subprocess.Popen(p_args, env=env, **kwargs)
+
+    stdout, stderr = proc.communicate()
+    rc = proc.returncode
+    if six.PY3 and not pdb:
+        stdout = stdout.decode()
+        stderr = stderr.decode()
+
+    return rc, stdout, stderr
+
+
+def _res_name(item):
+    """Return the resource name, used by pick_test_resources()"""
+    if isinstance(item, (tuple, list)):
+        return item[0].name
+    return item.name
+
+
+def pick_test_resources(res_list):
+    """
+    Return the list of resources to be tested.
+
+    The env.var "TESTRESOURCES" controls which resources are picked for the
+    test, as follows:
+
+    * 'random': (default) one random choice from the input list of resources.
+    * 'all': the complete input list of resources.
+    * '<pattern>': The resources with names matching the regexp pattern.
+
+    Parameters:
+      res_list (list of zhmcclient.BaseResource or tuple thereof):
+        List of resources to pick from. Tuple items are a resource and its
+        parent resources.
+
+    Returns:
+      list of zhmcclient.BaseResource: Picked list of resources.
+    """
+
+    test_res = os.getenv('TESTRESOURCES', 'random')
+
+    if test_res == 'random':
+        return [random.choice(res_list)]
+
+    if test_res == 'all':
+        return sorted(res_list, key=_res_name)
+
+    # match the pattern
+    ret_list = []
+    for item in res_list:
+        if re.search(test_res, _res_name(item)):
+            ret_list.append(item)
+    return sorted(ret_list, key=_res_name)
+
+
+def skipif_no_storage_mgmt_feature(cpc):
+    """
+    Skip the test if the "DPM Storage Management" feature is not enabled for
+    the specified CPC, or if the CPC does not yet support it.
+    """
+    try:
+        smf = cpc.feature_enabled('dpm-storage-management')
+    except ValueError:
+        smf = False
+    if not smf:
+        skip_warn("DPM Storage Mgmt feature not enabled or not supported "
+                  "on CPC {c}".format(c=cpc.name))
+
+
+def skipif_storage_mgmt_feature(cpc):
+    """
+    Skip the test if the "DPM Storage Management" feature is enabled for
+    the specified CPC.
+    """
+    try:
+        smf = cpc.feature_enabled('dpm-storage-management')
+    except ValueError:
+        smf = False
+    if smf:
+        skip_warn("DPM Storage Mgmt feature enabled on CPC {c}".
+                  format(c=cpc.name))
+
+
+def skip_warn(msg):
+    """
+    Issue an End2endTestWarning and skip the current pytest testcase with the
+    specified message.
+    """
+    warnings.warn(msg, End2endTestWarning, stacklevel=2)
+    pytest.skip(msg)


### PR DESCRIPTION
For details, see the commit message.

Note: This PR was originally on top of PR #412 (review only the delta), but has now been rebased to master after merging that PR.

Tested the initial end2end testcase successfully against the A224 HMC (with Python 2.7 and 3.9 on macOS)
The end2end tests do not run against a mocked environment yet - created issue #413 to fix that.