### PR TITLE
Release 1.7.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,16 +20,12 @@ Change log
 ----------
 
 
-Version 1.7.0.dev1
-^^^^^^^^^^^^^^^^^^
+Version 1.7.0
+^^^^^^^^^^^^^
 
-This version contains all fixes up to version 1.6.x.
+This version contains all fixes up to version 1.6.1.
 
-Released: not yet
-
-**Incompatible changes:**
-
-**Deprecations:**
+Released: 2023-05-16
 
 **Bug fixes:**
 
@@ -80,17 +76,9 @@ Released: not yet
 * Added two new commands 'console list-api-features' and 'cpc list-api-features'
   to support the new "API features" concept.
 
-**Cleanup:**
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/zhmccli/issues
-
 
 Version 1.6.0
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^
 
 This version contains all fixes up to version 1.5.1.
 

--- a/zhmccli/_version.py
+++ b/zhmccli/_version.py
@@ -25,4 +25,4 @@ __all__ = ['__version__']
 #:
 #: * "M.N.U.dev1": A not yet released version M.N.U
 #: * "M.N.U": A released version M.N.U
-__version__ = '1.7.0.dev1'
+__version__ = '1.7.0'


### PR DESCRIPTION
Please approve the release of zhmccli version 1.7.0 to Pypi