### PR TITLE
1.7: Fixed dependency on zhmcclient 1.8.1 to be from Pypi

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -106,8 +106,7 @@ wheel==0.38.1; python_version >= '3.7'
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
 
-# TODO: Enable again once 1.8.1 is released.
-# zhmcclient==1.8.1
+zhmcclient==1.8.1
 
 click==7.0; python_version <= '3.5'
 click==8.0.2; python_version >= '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,8 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-# TODO: Enable use of Pypi package again once 1.8.1 is released.
-zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@1.8/andy/fix-session-logoff
-# zhmcclient>=1.8.1  # Apache
+# zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@1.8/andy/fix-session-logoff
+zhmcclient>=1.8.1  # Apache
 
 # click <7.0 did not properly declare supported Python versions
 # click 8.0 has dropped support for Python 2.7,3.5


### PR DESCRIPTION
Rolls back PR #428 into 1.7.1.