### PR TITLE
Removed 'adapter-family' from 'adapter list' output

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -46,7 +46,8 @@ Released: not yet
   unit/function tests.
 
 * Added the 'state' and 'physical-channel-status' properties to the output
-  of the "adapter list" command. (issue #472)
+  of the "adapter list" command. Removed the redundant 'adapter-family' property
+  from the output. (issue #472)
 
 * Added 'short-name' and 'reserved-resources' (only when usage options are used)
   columns to the output of the 'partition list' command. (issue #468)

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -280,7 +280,6 @@ def cmd_adapter_list(cmd_ctx, cpc_name, options):
             'status',
             'state',
             'physical-channel-status',
-            'adapter-family',
             'type',
             'detected-card-type',
             'crypto-type',


### PR DESCRIPTION
For details, see the commit message.