### PR TITLE
Dropped Python 2.7 and 3.5 support; Removed licenses from dep files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,19 +35,9 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"3.5\", \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\" ], \
+            \"python-version\": [ \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"exclude\": [ \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
               { \
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.6\", \
@@ -60,28 +50,6 @@ jobs:
               } \
             ], \
             \"include\": [ \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"2.7\", \
-                \"package_level\": \"minimum\", \
-                \"container\": {\"image\": \"python:2.7.18-buster\"} \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"2.7\", \
-                \"package_level\": \"latest\", \
-                \"container\": {\"image\": \"python:2.7.18-buster\"} \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
@@ -102,34 +70,12 @@ jobs:
             \"include\": [ \
               { \
                 \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"2.7\", \
-                \"package_level\": \"minimum\", \
-                \"container\": {\"image\": \"python:2.7.18-buster\"} \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"2.7\", \
-                \"package_level\": \"latest\", \
-                \"container\": {\"image\": \"python:2.7.18-buster\"} \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
                 \"os\": \"macos-latest\", \
-                \"python-version\": \"3.5\", \
+                \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
@@ -139,7 +85,7 @@ jobs:
               }, \
               { \
                 \"os\": \"windows-latest\", \
-                \"python-version\": \"3.5\", \
+                \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
@@ -175,7 +121,6 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      if: ${{ ! ( matrix.python-version == '2.7' ) }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/.pylintrc
+++ b/.pylintrc
@@ -67,7 +67,6 @@ ignore-patterns=^\.#
 #       on the module ignore list. For details, see
 #       https://bitbucket.org/logilab/pylint/issues/223/ignored-modules-should-turn-no-name-in
 ignored-modules=distutils,
-                six,
                 builtins,
                 urllib,
                 lxml,
@@ -347,7 +346,7 @@ init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+redefining-builtins-modules=past.builtins,future.builtins,builtins,io
 
 
 [FORMAT]

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -20,38 +20,16 @@ security:
     #     reason: {text}    # optional: Reason for ignoring it. Will be reported in the Safety reports
     #     expires: {date}   # optional: Date when this ignore will expire
     ignore-vulnerabilities:
-        37504:
-            reason: Fixed Twine version requires Python>=3.6 and is used there
-        38330:
-            reason: Fixed Sphinx version requires Python>=3.5 and is used there
         39611:
-            reason: PyYAML full_load method or FullLoader is not used
-        39621:
-            reason: Fixed Pylint version requires Python>=3.6 and is used there
-        40291:
-            reason: Fixed Pip version requires Python>=3.6 and is used there
-        42559:
-            reason: Fixed Pip version requires Python>=3.6 and is used there; Pip is not shipped with this package
+            reason: Fixed PyYAML versions 5.4 to 6.0.0 do not work with Cython 3, and the full_load method or FullLoader is not used
         43975:
             reason: Fixed Urllib3 versions are excluded by requests
-        45185:
-            reason: Fixed Pylint version requires Python>=3.6.2 and is used there
-        45775:
-            reason: Fixed Sphinx version requires Python>=3.5 and is used there
-        47833:
-            reason: Fixed Click version requires Python>=3.6 and is used there
-        50885:
-            reason: Fixed Pygments version requires Python>=3.5 and is used there
-        50886:
-            reason: Fixed Pygments version requires Python>=3.5 and is used there
         51457:
             reason: Py package will no longer be fixed (latest version 1.11.0)
         51499:
             reason: Fixed Wheel version requires Python>=3.7 and is used there; Risk is on Pypi side
         52322:
             reason: Fixed GitPython version requires Python>=3.7 and is used there
-        52365:
-            reason: Fixed Certifi version requires Python>=3.6 and is used there
         52495:
             reason: Fixed Setuptools version requires Python>=3.7 and is used there; Risk is on Pypi side
         52518:
@@ -60,12 +38,6 @@ security:
             reason: Fixed requests version 2.31.0 requires Python>=3.7 and is used there
         58910:
             reason: Fixed pygments version 2.15.0 requires Python>=3.7 and is used there
-        59956:
-            reason: Fixed certifi version 2023.07.22 requires Python>=3.6 and is used there
-        59910:
-            reason: Fixed sphinx version 3.3.0 requires Python>=3.5 and is used there
-        59925:
-            reason: Fixed sphinx version 3.3.0 requires Python>=3.5 and is used there
         60350:
             reason: Fixed GitPython version 3.1.32 requires Python>=3.7 and is used there
         60789:

--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -9,12 +9,11 @@
 
 # Base dependencies (must be consistent with minimum-constraints.txt)
 
-pip>=10.0.1; python_version <= '3.5'
-pip>=21.2.4; python_version >= '3.6'
-setuptools>=39.0.1; python_version <= '3.6'
+pip>=21.2.4
+setuptools>=39.0.1; python_version == '3.6'
 setuptools>=40.6.0; python_version == '3.7'
 setuptools>=41.5.0; python_version >= '3.8' and python_version <= '3.9'
 setuptools>=49.0.0; python_version >= '3.10'
-wheel>=0.30.0; python_version <= '3.6'
+wheel>=0.30.0; python_version == '3.6'
 wheel>=0.32.0; python_version == '3.7'
 wheel>=0.33.5; python_version >= '3.8'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,13 +11,20 @@
 # Runtime dependencies:
 -r requirements.txt
 
+# six
+# tox 3.17 requires six>=1.14.0 (tox 4.0 no longer uses six)
+# zhmcclient 1.11 requires six>=1.14.0 up to py39 and six>=1.16.0 from py310 on
+# python-dateutil 2.8 requires six>=1.5
+# sphinx-git 11.0 requires six (any version)
+# coverage imports six when testing, but does not declare it in its dependencies. check_reqs still needs it.
+six>=1.14.0; python_version <= '3.9'
+six>=1.16.0; python_version >= '3.10'
 
 # Tox
 tox>=2.5.0
 
 # Virtualenv
 # build requires virtualenv.cli_run which was added in 20.1
-# virtualenv 20.0 requires six<2,>=1.12.0
 virtualenv>=20.1.0
 
 # PEP517 package builder, used in Makefile
@@ -26,132 +33,87 @@ build>=0.5.0
 pep517>=0.9.1
 
 # Safety CI by pyup.io
-# Safety is run only on Python >=3.6
-safety>=2.2.0; python_version >= '3.6'
-dparse>=0.6.2; python_version >= '3.6'
+safety>=2.2.0
+dparse>=0.6.2
 
 # Unit test:
-# pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
-pytest>=4.6.11,<5.0.0; python_version == '2.7'
-pytest>=4.6.11; python_version >= '3.5' and python_version <= '3.9'
+pytest>=4.6.11; python_version <= '3.9'
 pytest>=6.2.5; python_version >= '3.10'
 # flake8 up to 6.0.0 has not yet adjusted to the removed interfaces of importlib-metadata 5.0
-importlib-metadata>=0.22,<4.3; python_version <= '3.6'
+importlib-metadata>=0.22,<4.3; python_version == '3.6'
 importlib-metadata>=1.1.0,<4.3; python_version >= '3.7'
 
 # packaging is used by pytest, pip-check-reqs, sphinx
 # packaging>=20.5 is needed by pip-check-reqs 2.4.3 but it requires only packaging>=16.0
-# packaging 21.0 removed support for Python <3.6
 # packaging 22.0 removed support for py36
-packaging>=20.5; python_version <= '3.5'
-packaging>=21.0,<22.0; python_version >= '3.6'
+packaging>=21.0,<22.0
 
-# colorama 0.4.3 has removed support for Python < 3.5
-colorama>=0.3.9; python_version == '2.7'
-colorama>=0.4.5; python_version >= '3.5'
+colorama>=0.4.5
 
 # Coverage reporting (no imports, invoked via coveralls script):
 coverage>=5.5
 pytest-cov>=2.12.1
-# coveralls 2.0 has removed support for Python 2.7
-git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-coveralls>=3.3.0; python_version >= '3.5'
-
-# PyYAML: covered in direct deps for development
+coveralls>=3.3.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
-# Sphinx 2.0.0 removed support for Python 2.7
 # Sphinx 4.0.0 breaks autodocsumm and needs to be excluded
 # Sphinx <4.3.0 requires docutils <0.18 due to an incompatibility
-# Sphinx 3.0.4 fixes safety issues 45775,38330
 # Sphinx <4.2.0 fails on Python 3.10 because it tries to import non-existing
 #   types.Union. This also drives docutils>=0.14.
-# Sphinx pins docutils to <0.18 (some versions even to <0.17) but the package
-#   version resolver in the pip version used on py27 ignores package dependencies
-Sphinx>=1.7.6,<2.0.0; python_version == '2.7'
-Sphinx>=3.5.4,!=4.0.0,<4.3.0; python_version >= '3.5' and python_version <= '3.9'
+Sphinx>=3.5.4,!=4.0.0,<4.3.0; python_version <= '3.9'
 Sphinx>=4.2.0; python_version >= '3.10'
-docutils>=0.13.1,<0.17; python_version == '2.7'
-docutils>=0.13.1,<0.17; python_version >= '3.5' and python_version <= '3.9'
+docutils>=0.13.1,<0.17; python_version <= '3.9'
 docutils>=0.14,<0.17; python_version == '3.10'
 docutils>=0.16,<0.17; python_version >= '3.11'
 sphinx-git>=10.1.1
-# GitPython version 3.0.0 and newer does not support Python 2.7
 # GitPython version 3.1.24 requires Python >=3.7
-# GitPython version 3.1.27 fixes safety issue #52518
-# GitPython 3.1.30 fixes safety issues 52322,52518
-GitPython>=2.1.1,<3.0.0; python_version == '2.7'
-GitPython>=2.1.1; python_version >= '3.5' and python_version <= '3.6'
+GitPython>=2.1.1; python_version == '3.6'
 GitPython>=3.1.37; python_version >= '3.7'
-# Pygments 2.7.4 fixes safety issues 50885,50886
-Pygments>=2.4.1; python_version == '2.7'
-Pygments>=2.7.4; python_version >= '3.5' and python_version <= '3.6'
+Pygments>=2.7.4; python_version == '3.6'
 Pygments>=2.15.0; python_version >= '3.7'
 sphinx-rtd-theme>=1.0.0
-# Babel 2.7.0 fixes an ImportError for MutableMapping which starts failing on Python 3.10
-# Babel 2.9.1 fixes safety issue 42203
 Babel>=2.9.1
 
 # PyLint (no imports, invoked via pylint script)
-# Pylint is not run on py27 anymore
 # Pylint requires astroid
-# Pylint 1.x / astroid 1.x supports py27 and py34/35/36
-# Pylint 2.0 / astroid 2.0 removed py27, added py37
-# Pylint 2.4 / astroid 2.3 removed py34
-# Issue #2673: Pinning Pylint to <2.7.0 is a circumvention for Pylint issue
-#   https://github.com/PyCQA/pylint/issues/4120 that appears in Pylint 2.7.0.
-#   Pylint 2.10 has fixed the issue.
-# Pylint 2.7.0 fixes safety issue 39621
-# Pylint 2.13.0 fixes safety issue 45185
-pylint>=2.5.2,<2.7.0; python_version == '3.5'
 pylint>=2.13.0,<2.14.0; python_version == '3.6'
 pylint>=2.13.0; python_version >= '3.7' and python_version <= '3.10'
 pylint>=2.15.0; python_version >= '3.11'
-astroid>=2.4.0,<2.6.0; python_version == '3.5'
-astroid>=2.11.0; python_version >= '3.6' and python_version <= '3.10'
+astroid>=2.11.0; python_version <= '3.10'
 astroid>=2.12.4; python_version >= '3.11'
-typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
+typed-ast>=1.4.0,<1.5.0; python_version <= '3.7' and implementation_name=='cpython'
 # lazy-object-proxy is used by astroid
-lazy-object-proxy>=1.4.3; python_version >= '3.5'
-wrapt>=1.11.2; python_version >= '3.5' and python_version <= '3.10'
+lazy-object-proxy>=1.4.3
+wrapt>=1.11.2; python_version <= '3.10'
 wrapt>=1.14; python_version >= '3.11'
 # platformdirs is used by pylint starting with its 2.10
-platformdirs>=2.2.0; python_version >= '3.6'
-# isort 5.0.0 removed support for py27,py35
+platformdirs>=2.2.0
 # isort 4.2.8 fixes a pylint issue with false positive on import order of ssl on Windows
 # isort 4.3.8 fixes an issue with py310 and works on py310 (Note that isort 5.10.0 has official support for py310)
 isort>=4.3.8
 # Pylint 2.14 uses tomlkit>=0.10.1 and requires py>=3.7
 tomlkit>=0.10.1; python_version >= '3.7'
 # dill is used by pylint >=2.13
-dill>=0.2; python_version >= '3.6' and python_version <= '3.10'
+dill>=0.2; python_version <= '3.10'
 dill>=0.3.6; python_version >= '3.11'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
-# flake8 3.9.0 has removed support for py34 and pip 19.1.1 on py34 does not deal
-# well with its pinned dependencies, so we need to repeat these for py34.
 # flake8 4.0.0 fixes an AttributeError on Python 3.10.
 flake8>=3.8.0; python_version <= '3.9'
 flake8>=4.0.0; python_version >= '3.10'
 mccabe>=0.6.0
-pycodestyle>=2.6.0,<2.8.0; python_version == '2.7'
-pycodestyle>=2.6.0; python_version >= '3.5' and python_version <= '3.9'
+pycodestyle>=2.6.0; python_version <= '3.9'
 pycodestyle>=2.8.0; python_version >= '3.10'
-pyflakes>=2.2.0,<2.4.0; python_version == '2.7'
-pyflakes>=2.2.0; python_version >= '3.5' and python_version <= '3.9'
+pyflakes>=2.2.0; python_version <= '3.9'
 pyflakes>=2.4.0; python_version >= '3.10'
 entrypoints>=0.3.0
-functools32>=3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
 # Twine (no imports, invoked via twine script):
-# twine 2.0.0 removed support for Python < 3.6
-twine>=1.8.1,<2.0.0; python_version <= '3.5'
-twine>=3.0.0; python_version >= '3.6'
+twine>=3.0.0
 # readme-renderer 23.0 has made cmarkgfm part of extras (it fails on Cygwin)
 # readme-renderer 25.0 or higher is needed to address issue on Windows with py39
-readme-renderer>=23.0; python_version == '2.7'
-readme-renderer>=25.0; python_version >= '3.5'
+readme-renderer>=25.0
 
 # Unit test (indirect dependencies):
 # Pluggy 0.12.0 has a bug causing pytest plugins to fail loading on py38
@@ -159,49 +121,9 @@ pluggy>=0.13.1
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree>=2.2.0
-# pip-check-reqs is not used on Python 2.7
 # pip-check-reqs 2.3.2 is needed to have proper support for pip<21.3.
 # pip-check-reqs 2.4.0 requires Python>=3.8.
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
-pip-check-reqs>=2.3.2; python_version >= '3.5' and python_version <= '3.7'
+pip-check-reqs>=2.3.2; python_version <= '3.7'
 pip-check-reqs>=2.4.3,!=2.5.0; python_version >= '3.8'
-
-# Indirect dependencies (normally commented out, only listed to document their license):
-
-# alabaster # BSD, from Sphinx
-# atomicwrites # TBD
-# attrs # TBD
-# backports.functools-lru-cache # MIT, from pylint
-# bleach # Apache, from ???
-# configparser # MIT, from pylint and from flake8 for py<3.2
-# contextlib2 # TBD
-# coverage # Apache-2.0, from pytest-cov
-# docutils # public domain | Python | 2-Clause BSD | GPL 3, from Sphinx
-# enum34 # BSD, from astroid
-# funcsigs # Apache, from mock for py<3.3
-# futures # TBD
-# gitdb2 # BSD, from GitPython
-# gitdb # BSD, from GitPython
-# imagesize # MIT, from Sphinx
-# isort # MIT, from pylint
-# Jinja2 # BSD, from Sphinx
-# keyring # TBD
-# MarkupSafe # BSD, from Jinja2 -> Sphinx
-# more-itertools # TBD
-# packaging # TBD
-# pathlib2 # MIT, from ???
-# pkginfo # MIT, from twine
-# py # MIT, from pytest
-# pyparsing # TBD
-# requests-toolbelt # Apache 2.0, from twine
-# scandir # New BSD, from pathlib2 for py<3.6 -> pytest
-# singledispatch # MIT, from pylint
-# smmap2 # BSD, from gitdb2 -> GitPython
-# smmap # BSD, from gitdb -> GitPython
-# snowballstemmer # BSD, from Sphinx
-# sphinxcontrib-websupport # BSD, from Sphinx>=1.6.1
-# tqdm # MPL 2.0, MIT, from twine>=1.9.1
-# typing # PSFL, from Sphinx>=1.6.1 for py<3.5
-# webencodings # BSD, from ???
-# zipp # TBD

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,13 @@ Released: not yet
 
 **Incompatible changes:**
 
+* Dropped support for Python 2.7 and 3.5. These Python versions went out
+  of support by the PSF in 2020. If you still use these Python versions
+  today, you should seriously consider upgrading to a supported Python
+  version.
+  As far as the zhmccli package goes, you can still use versions up to
+  1.9.x on Python 2.7 and 3.5.
+
 **Deprecations:**
 
 **Bug fixes:**

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -47,7 +47,7 @@ The zhmccli package is supported in these environments:
 
 * Operating systems: Linux, Windows, OS-X
 
-* Python versions: 2.7, 3.5, and higher 3.x
+* Python versions: 3.6 and higher
 
 * HMC versions: 2.11.1 and higher
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -15,68 +15,7 @@
 # the minimum versions required in requirements.txt and dev-requirements.txt.
 
 
-# Dependencies for installation with Pip (must be installed in a separate pip call)
-#
-# Info: OS-installed package versions for some Linux distros:
-# * RHEL/CentOS 7.4.1708:
-#   Python      2.7.5     2013-05-15
-#   pip         8.1.2     2016-05-11 (epel)
-#   setuptools  0.9.8     2013-07-25
-#   wheel       0.24.0    2014-07-06 (epel)
-#   pbr         1.8.1     2015-10-07 (epel)
-# * Ubuntu 16.04.03:
-#   Python      2.7.12    2016-11-19
-#   pip         8.1.1     2016-03-17
-#   setuptools  20.7.0    2016-04-10
-#   wheel       0.29.0    2016-02-06
-#   pbr         1.8.0     2015-09-14
-# * Ubuntu 17.04:
-#   Python      2.7.12    2016-11-19
-#   pip         9.0.1     2016-11-06
-#   setuptools  33.1.1    2017-01-16
-#   wheel       0.29.0    2016-02-06
-#   pbr         1.10.0    2016-05-23
-# * Ubuntu 18.04:
-#   Python      2.7.15
-#   Python3     3.6.5
-#   pip         9.0.1     (py2+py3)
-#   setuptools  39.0.1    (py2+py3)
-#   wheel       0.30.0    (py2+py3)
-# * Ubuntu 19.04:
-#   Python      2.7.16
-#   Python3     3.7.3
-#   pip         18.1      (py2+py3)
-#   setuptools  40.8.0    (py2+py3)
-#   wheel       0.32.3    (py2+py3)
-
-
 # Base dependencies (must be consistent with base-requirements.txt)
-
-# Info: Python version supported by base packages (added / removed)
-# * Python 2.7 support:
-#   pip         ?
-#   setuptools  ? / 45.0.0
-#   wheel       ?
-# * Python 3.4 support:
-#   pip         ? / 19.2
-#   setuptools  ? / 44.0.0
-#   wheel       ? / 0.34.0
-# * Python 3.5 support:
-#   pip         8.0
-#   setuptools  18.3
-#   wheel       0.30.0
-# * Python 3.6 support:
-#   pip         10.0.0
-#   setuptools  34.0.0
-#   wheel       0.30.0
-# * Python 3.7 support:
-#   pip         18.1
-#   setuptools  40.6.0
-#   wheel       0.32.0
-# * Python 3.8 support:
-#   pip         19.3.1
-#   setuptools  41.5.0
-#   wheel       0.33.5
 
 # For the base packages, we use the versions from Ubuntu 18.04 as a general
 # minimum, and then increase it to the first version that introduced support
@@ -85,22 +24,13 @@
 # pip 18.0 is needed on pypy3 (py36) to support constraints like cffi!=1.11.3,>=1.8.
 # pip 18.1 supports PEP-508 URLs, so the deprecated dependency_links no longer needs to be used.
 # Pip 20.2 introduced a new resolver whose backtracking had issues that were resolved only in 21.2.2.
-# Pip 21.0 removed support for Python<=3.5
 # pip>=21.0 is needed for the cryptography package on Windows on GitHub Actions.
-# pip 19.2 fixes safety issue 38765
-# pip 21.1 fixes safety issues 42559,40291
-pip==19.3.1; python_version <= '3.5'
 pip==21.2.4; python_version >= '3.6' and python_version <= '3.9'
 pip==23.0.1; python_version >= '3.10'
-# setuptools 51.0.0 removed support for py35
 # setuptools 59.7.0 removed support for py36
-# setuptools 65.5.1 fixes safety issue 52495
-setuptools==39.0.1; python_version == '2.7'
-setuptools==50.3.2; python_version == '3.5'
 setuptools==59.6.0; python_version == '3.6'
 setuptools==65.5.1; python_version >= '3.7'
-# wheel 0.38.1 fixes safety issue 51499
-wheel==0.30.0; python_version <= '3.6'
+wheel==0.30.0; python_version == '3.6'
 wheel==0.38.1; python_version >= '3.7'
 
 
@@ -108,25 +38,18 @@ wheel==0.38.1; python_version >= '3.7'
 
 zhmcclient==1.10.0
 
-click==7.0; python_version <= '3.5'
-click==8.0.2; python_version >= '3.6'
-click-repl==0.1.6; python_version <= '3.5'
-click-repl==0.2; python_version >= '3.6'
+click==8.0.2
+click-repl==0.2
 click-spinner==0.1.6
 progressbar2==3.12.0
-# virtualenv 20.0 requires six>=1.12.0 on py>=3.8
-# tox 3.17 requires six>=1.14.0
-six==1.14.0; python_version <= '3.9'
-six==1.16.0; python_version >= '3.10'
 tabulate==0.8.2; python_version <= '3.9'
 tabulate==0.8.8; python_version >= '3.10'
 python-dateutil==2.8.2
 
 # prompt-toolkit is pulled in by click-repl.
-prompt-toolkit==1.0.15; python_version == '2.7'
-prompt-toolkit==2.0.1; python_version >= '3.5'
+prompt-toolkit==2.0.1
 
-# PyYAML is pulled in by zhmcclient and dparse
+# PyYAML is pulled in by zhmccli, zhmcclient, yamlloader
 PyYAML==5.3.1
 
 jsonschema==3.0.1
@@ -140,9 +63,7 @@ pyrsistent==0.15.1
 
 # Indirect dependencies for runtime (must be consistent with requirements.txt)
 
-# certifi 2022.12.07 fixes safety issue 52365
-certifi==2019.9.11; python_version <= '3.5'
-certifi==2023.07.22; python_version >= '3.6'
+certifi==2023.07.22
 chardet==3.0.3
 decorator==4.0.11
 docopt==0.6.2
@@ -152,11 +73,15 @@ pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
 stomp.py==4.1.23
 wcwidth==0.2.6
-requests==2.25.0; python_version <= '3.6'
+requests==2.25.0; python_version == '3.6'
 requests==2.31.0; python_version >= '3.7'
 
 
 # Direct dependencies for development (must be consistent with dev-requirements.txt)
+
+# six (only needed by packages that still support Python 2)
+six==1.14.0; python_version <= '3.9'
+six==1.16.0; python_version >= '3.10'
 
 # Tox
 tox==2.5.0
@@ -170,57 +95,48 @@ build==0.5.0
 pep517==0.9.1
 
 # Safety CI by pyup.io
-# Safety is run only on Python >=3.6
-safety==2.2.0; python_version >= '3.6'
-dparse==0.6.2; python_version >= '3.6'
+safety==2.2.0
+dparse==0.6.2
 
 # Unit test (imports into testcases):
-# pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
-pytest==4.6.11; python_version <= '3.6' and python_version <= '3.9'
+pytest==4.6.11; python_version >= '3.6' and python_version <= '3.9'
 pytest==6.2.5; python_version >= '3.10'
-importlib-metadata==0.22; python_version <= '3.6'
+importlib-metadata==0.22; python_version == '3.6'
 importlib-metadata==1.1.0; python_version >= '3.7'
 
-packaging==20.5; python_version <= '3.5'
-packaging==21.0; python_version >= '3.6'
+packaging==21.0
 
 # Coverage reporting (no imports, invoked via coveralls script):
 coverage==5.5
 pytest-cov==2.12.1
-# handled by dev-requirements.txt: git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-coveralls==3.3.0; python_version >= '3.5'
+coveralls==3.3.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
-Sphinx==1.7.6; python_version == '2.7'
-Sphinx==3.5.4; python_version >= '3.5' and python_version <= '3.9'
+Sphinx==3.5.4; python_version >= '3.6' and python_version <= '3.9'
 Sphinx==4.2.0; python_version >= '3.10'
-docutils==0.13.1; python_version == '2.7'
-docutils==0.13.1; python_version >= '3.5' and python_version <= '3.9'
+docutils==0.13.1; python_version >= '3.6' and python_version <= '3.9'
 docutils==0.14; python_version == '3.10'
 docutils==0.16; python_version >= '3.11'
 sphinx-git==10.1.1
-GitPython==2.1.1; python_version <= '3.6'
+GitPython==2.1.1; python_version == '3.6'
 GitPython==3.1.37; python_version >= '3.7'
 sphinxcontrib-websupport==1.1.2
-Pygments==2.4.1; python_version == '2.7'
-Pygments==2.7.4; python_version >= '3.5' and python_version <= '3.6'
+Pygments==2.7.4; python_version == '3.6'
 Pygments==2.15.0; python_version >= '3.7'
 sphinx-rtd-theme==1.0.0
 Babel==2.9.1
 
 # PyLint (no imports, invoked via pylint script):
-pylint==2.5.2; python_version == '3.5'
 pylint==2.13.0; python_version >= '3.6' and python_version <= '3.10'
 pylint==2.15.0; python_version >= '3.11'
-astroid==2.4.0; python_version == '3.5'
 astroid==2.11.0; python_version >= '3.6' and python_version <= '3.10'
 astroid==2.12.4; python_version >= '3.11'
-typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
-lazy-object-proxy==1.4.3; python_version >= '3.5'
-wrapt==1.12; python_version >= '3.5' and python_version <= '3.10'
+typed-ast==1.4.0; python_version >= '3.6' and python_version <= '3.7' and implementation_name=='cpython'
+lazy-object-proxy==1.4.3
+wrapt==1.12; python_version >= '3.6' and python_version <= '3.10'
 wrapt==1.14; python_version >= '3.11'
-platformdirs==2.2.0; python_version >= '3.6'
+platformdirs==2.2.0
 isort==4.3.8
 tomlkit==0.10.1; python_version >= '3.7'
 dill==0.2; python_version >= '3.6' and python_version <= '3.10'
@@ -235,14 +151,11 @@ pycodestyle==2.8.0; python_version >= '3.10'
 pyflakes==2.2.0; python_version <= '3.9'
 pyflakes==2.4.0; python_version >= '3.10'
 entrypoints==0.3.0
-functools32==3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
 # Twine (no imports, invoked via twine script):
-twine==1.8.1; python_version <= '3.5'
-twine==3.0.0; python_version >= '3.6'
+twine==3.0.0
 # readme-renderer (used by twine, uses Pygments)
-readme-renderer==23.0; python_version == '2.7'
-readme-renderer==25.0; python_version >= '3.5'
+readme-renderer==25.0
 
 # Unit test (indirect dependencies):
 # pluggy (used by pytest)
@@ -251,7 +164,7 @@ pluggy==0.13.1
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree==2.2.0
-pip-check-reqs==2.3.2; python_version >= '3.5' and python_version <= '3.7'
+pip-check-reqs==2.3.2; python_version >= '3.6' and python_version <= '3.7'
 pip-check-reqs==2.4.3; python_version >= '3.8'
 
 # Indirect dependencies for development (must be consistent with dev-requirements.txt)
@@ -259,61 +172,47 @@ pip-check-reqs==2.4.3; python_version >= '3.8'
 alabaster==0.7.9
 appdirs==1.4.3
 atomicwrites==1.4.0
-attrs==18.2.0; python_version == '2.7'
-attrs==19.2.0; python_version >= '3.5'
-backports.functools-lru-cache==1.5; python_version == "2.7"
+attrs==19.2.0
 bleach==3.3.0
 # tox 4.0.0 started using cachetools and requires cachetools>=5.2
 cachetools==5.2.0; python_version >= '3.7'
 clint==0.5.1
-colorama==0.3.9; python_version == '2.7'
-colorama==0.4.5; python_version >= '3.5'
+colorama==0.4.5
 configparser==4.0.2
 contextlib2==0.6.0
 distlib==0.3.4
-enum34==1.1.6; python_version == "2.7"
 filelock==3.2.0
-funcsigs==1.0.2; python_version == "2.7"
-futures==3.3.0; python_version == "2.7"
-gitdb2==2.0.0; python_version <= '3.6'
-gitdb==4.0.1; python_version == '3.5'
-gitdb==4.0.8; python_version >= '3.6'
+gitdb2==2.0.0; python_version == '3.6'
+gitdb==4.0.8
 imagesize==0.7.1
 importlib-resources==1.4.0
-iniconfig==2.0.0; python_version >= "3.6"  # used by pytest since its 6.0.0 which requires py36
-Jinja2==2.11.3; python_version <= '3.5'
-Jinja2==3.0.0; python_version >= '3.6'
-keyring==17.0.0; python_version >= '3.5'
-MarkupSafe==1.1.1; python_version <= '3.5'
-MarkupSafe==2.0.0; python_version >= '3.6'
+iniconfig==2.0.0  # used by pytest since its 6.0.0 which requires py36
+Jinja2==3.0.0
+keyring==17.0.0
+MarkupSafe==2.0.0
 more-itertools==5.0.0
 # pathlib2 (used by virtualenv on py<3.4 on non-Windows)
 pathlib2==2.3.3; python_version < '3.4' and sys_platform != 'win32'
 # twine 3.0.0 depends on pkginfo>=1.4.2
 pkginfo==1.4.2
 py==1.11.0
-pyparsing==2.4.7; python_version <= '3.5'
-pyparsing==3.0.7; python_version >= '3.6'
+pyparsing==3.0.7
 # tox 4.0.0 started using pyproject-api and requires pyproject-api>=1.2.1
 pyproject-api==1.2.1; python_version >= '3.7'
 # build is using pyproject-hooks
 pyproject-hooks==1.0.0; python_version >= '3.7'
 requests-toolbelt==0.8.0
-rich==12.0.0; python_version >= '3.6'
-rfc3986==1.3.0; python_version == '3.5'
-rfc3986==1.4.0; python_version >= "3.6"  # used by twine since its 3.2.0 which requires py36
-scandir==1.9.0; python_version == '2.7'
-singledispatch==3.4.0.3; python_version == "2.7"
-smmap2==2.0.1; python_version == '2.7'  # requires smmap>=3.0.1
+rich==12.0.0
+rfc3986==1.4.0  # used by twine since its 3.2.0 which requires py36
 smmap==3.0.1
 snowballstemmer==1.2.1
-sphinxcontrib-applehelp==1.0.0; python_version >= '3.5'
-sphinxcontrib-devhelp==1.0.0; python_version >= '3.5'
-sphinxcontrib-htmlhelp==1.0.0; python_version >= '3.5' and python_version <= '3.9'
+sphinxcontrib-applehelp==1.0.0
+sphinxcontrib-devhelp==1.0.0
+sphinxcontrib-htmlhelp==1.0.0; python_version <= '3.9'
 sphinxcontrib-htmlhelp==2.0.0; python_version >= '3.10'
-sphinxcontrib-jsmath==1.0.0; python_version >= '3.5'
-sphinxcontrib-qthelp==1.0.0; python_version >= '3.5'
-sphinxcontrib-serializinghtml==1.1.5; python_version >= '3.5'
+sphinxcontrib-jsmath==1.0.0
+sphinxcontrib-qthelp==1.0.0
+sphinxcontrib-serializinghtml==1.1.5
 toml==0.10.0  # used by pylint and pytest since some version
 # tomli 2.0.0 removed support for py36
 tomli==1.1.0; python_version == '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,67 +10,39 @@
 # Direct dependencies (except pip, setuptools, wheel):
 
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.10.0  # Apache
+zhmcclient>=1.10.0
 
-# click <7.0 did not properly declare supported Python versions
-# click 8.0 has dropped support for Python 2.7,3.5
-# safety 2.2.0 depends on click>=8.0.2 and is run only on Python>=3.6
-click>=7.0,<8.0; python_version <= '3.5'
-click>=8.0.2; python_version >= '3.6'
+# safety 2.2.0 depends on click>=8.0.2
+click>=8.0.2
 
-# click-repl 0.2 is needed for compatibility with Click 8.0 (see issue #819 click-repl incompatible)
-click-repl>=0.1.6; python_version <= '3.5'
-click-repl>=0.2; python_version >= '3.6'
+# click-repl 0.2 is needed for compatibility with Click 8.0 (see click-repl issue #819)
+click-repl>=0.2
 
-click-spinner>=0.1.6 # MIT
-progressbar2>=3.12.0 # BSD
-six>=1.14.0; python_version <= '3.9' # MIT
-six>=1.16.0; python_version >= '3.10' # MIT
-tabulate>=0.8.2; python_version <= '3.9' # MIT
-tabulate>=0.8.8; python_version >= '3.10' # MIT
-python-dateutil>=2.8.2  # Apache, BSD
+click-spinner>=0.1.6
+progressbar2>=3.12.0
+tabulate>=0.8.2; python_version <= '3.9'
+tabulate>=0.8.8; python_version >= '3.10'
+python-dateutil>=2.8.2
 
-# prompt-toolkit is pulled in by click-repl.
 # prompt-toolkit>=2.0 conflicts with ipython and jupyter-console.
-# prompt-toolkit>=3.0 does not support py27.
-prompt-toolkit>=1.0.15,<2.0.0; python_version == '2.7'
-prompt-toolkit>=2.0.1; python_version >= '3.5'
+prompt-toolkit>=2.0.1
 
-# PyYAML 5.3 has removed support for Python 3.4
-# PyYAML 5.3 fixed narrow build error on Python 2.7
-# PyYAML 5.3.1 addressed issue 38100 reported by safety
-# PyYAML 5.2 addressed issue 38639 reported by safety
-# PyYAML 5.4 fixes safety issue 39611
-# PyYAML 5.3 has wheel archives for Python 2.7, 3.5 - 3.9
-# PyYAML 5.4 has wheel archives for Python 2.7, 3.6 - 3.9
-# PyYAML 6.0 has wheel archives for Python 3.6 - 3.11
-# PyYAML 5.4 and 6.0.0 fails install since Cython 3 was released, see issue
-#   https://github.com/yaml/pyyaml/issues/724.
-PyYAML>=5.3.1; python_version <= '3.5'
-PyYAML>=5.3.1,!=5.4.0,!=5.4.1; python_version >= '3.6' and python_version <= '3.11'
+# PyYAML 5.3.x has wheel archives for Python 2.7, 3.5 - 3.9
+# PyYAML 5.4.x has wheel archives for Python 2.7, 3.6 - 3.9
+# PyYAML 6.0.0 has wheel archives for Python 3.6 - 3.11
+# PyYAML 6.0.1 has wheel archives for Python 3.6 - 3.12
+# PyYAML versions without wheel archives fail install since Cython 3 was
+#   released, see https://github.com/yaml/pyyaml/issues/724.
+PyYAML>=5.3.1,!=5.4.0,!=5.4.1; python_version <= '3.11'
 PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
 
 jsonschema>=3.0.1
 yamlloader>=0.5.5
 
-# urllib3 is used to disable warnings
-urllib3>=1.26.5  # MIT
+urllib3>=1.26.5
 
 
-# Indirect dependencies (commented out, only listed to document their license):
+# Indirect dependencies that need to be adjusted for some reason:
 
-# MIT, from jsonschema>=3.0
-# pyrsistent 0.15.0 started using the FileNotFoundError built-in exception that
-# was added only in Python 3. pyrsistent 0.15.1 fixed that by defining it locally for py27.
+# pyrsistent is used by jsonschema 3.x (no longer by jsonschema 4.x)
 pyrsistent>=0.15.1
-
-# certifi # MPL 2.0, from requests
-# chardet # LGPL, from requests
-# decorator # BSD, from zhmcclient
-# docopt # MIT, from stomp.py
-# idna # BSD, from requests
-# python-utils # BSD, from progressbar2
-# pytz # MIT, from zhmcclient
-# requests # Apache, from zhmcclient
-# stomp.py # Apache, from zhmcclient
-# wcwidth # MIT, from prompt-toolkit

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setuptools.setup(
     # Keep these Python versions in sync with:
     # - Section "Supported environments" in docs/intro.rst
     # - Version checking in zhmccli/_version.py
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -123,10 +123,7 @@ setuptools.setup(
         'Intended Audience :: Information Technology',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tests/end2end/utils.py
+++ b/tests/end2end/utils.py
@@ -23,7 +23,6 @@ import re
 import subprocess
 import random
 import warnings
-import six
 import pytest
 import zhmcclient
 
@@ -187,7 +186,7 @@ def run_zhmc(args, env=None, pdb_=False, log=False):
 
     stdout, stderr = proc.communicate()
     rc = proc.returncode
-    if six.PY3 and not pdb_:
+    if not pdb_:
         stdout = stdout.decode()
         stderr = stderr.decode()
 

--- a/tests/function/utils.py
+++ b/tests/function/utils.py
@@ -24,7 +24,6 @@ import re
 import tempfile
 from subprocess import Popen, PIPE
 from copy import copy
-import six
 
 import zhmcclient_mock
 from zhmccli.zhmccli import cli
@@ -97,7 +96,7 @@ def call_zhmc_child(args, env=None):
     assert isinstance(args, (list, tuple))
     cmd_args = [cli_cmd]
     for arg in args:
-        if not isinstance(arg, six.text_type):
+        if isinstance(arg, bytes):
             arg = arg.decode('utf-8')
         cmd_args.append(arg)
 
@@ -112,9 +111,9 @@ def call_zhmc_child(args, env=None):
     stdout_str, stderr_str = proc.communicate()
     rc = proc.returncode
 
-    if isinstance(stdout_str, six.binary_type):
+    if isinstance(stdout_str, bytes):
         stdout_str = stdout_str.decode('utf-8')
-    if isinstance(stderr_str, six.binary_type):
+    if isinstance(stderr_str, bytes):
         stderr_str = stderr_str.decode('utf-8')
 
     return rc, stdout_str, stderr_str
@@ -201,7 +200,7 @@ def call_zhmc_inline(args, env=None, faked_session=None):
     assert isinstance(args, (list, tuple))
     sys.argv = [cli_cmd]
     for arg in args:
-        if not isinstance(arg, six.text_type):
+        if isinstance(arg, bytes):
             arg = arg.decode('utf-8')
         sys.argv.append(arg)
 
@@ -255,9 +254,9 @@ def call_zhmc_inline(args, env=None, faked_session=None):
         tmp_stdout.seek(0)
         stdout_str = tmp_stdout.read()
 
-    if isinstance(stdout_str, six.binary_type):
+    if isinstance(stdout_str, bytes):
         stdout_str = stdout_str.decode('utf-8')
-    if isinstance(stderr_str, six.binary_type):
+    if isinstance(stderr_str, bytes):
         stderr_str = stderr_str.decode('utf-8')
 
     # Note that the click package on Windows writes '\n' at the Python level

--- a/tox.ini
+++ b/tox.ini
@@ -9,18 +9,12 @@
 [tox]
 minversion = 2.0
 envlist =
-    py27
-    py35
     py36
     py37
     py38
     py39
     py310
     py311
-    win64_py27_32
-    win64_py27_64
-    win64_py35_32
-    win64_py35_64
     win64_py36_32
     win64_py36_64
     win64_py37_32
@@ -33,10 +27,7 @@ envlist =
     win64_py310_64
     win64_py311_32
     win64_py311_64
-    cygwin32_py27
-    cygwin64_py27
     cygwin64_py36
-    msys64_py27
 
 skip_missing_interpreters = true
 
@@ -75,14 +66,6 @@ commands =
     make develop pip_list
     sh -c "export TESTCASES={posargs}; make test"
 
-[testenv:py27]
-platform = linux2|darwin
-basepython = python2.7
-
-[testenv:py35]
-platform = linux2|darwin
-basepython = python3.5
-
 [testenv:py36]
 platform = linux2|darwin
 basepython = python3.6
@@ -109,30 +92,6 @@ basepython = python3.11
 
 # Note: The basepython file paths for the win64* tox environments may need to
 #       be customized.
-
-[testenv:win64_py27_32]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python27;{env:PATH}
-
-[testenv:win64_py27_64]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python27-x64;{env:PATH}
-
-[testenv:win64_py35_32]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python35;{env:PATH}
-
-[testenv:win64_py35_64]
-platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python35-x64;{env:PATH}
 
 [testenv:win64_py36_32]
 platform = win32
@@ -206,18 +165,6 @@ basepython = python
 setenv =
     PATH = C:\Python311-x64;{env:PATH}
 
-[testenv:cygwin32_py27]
-platform = cygwin
-basepython = python2.7
-
-[testenv:cygwin64_py27]
-platform = cygwin
-basepython = python2.7
-
 [testenv:cygwin64_py36]
 platform = cygwin
 basepython = python3.6m
-
-[testenv:msys64_py27]
-platform = msys
-basepython = python2.7

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -26,7 +26,6 @@ import shutil
 import threading
 import re
 import jsonschema
-import six
 import click
 import click_spinner
 from tabulate import tabulate
@@ -430,7 +429,7 @@ def original_options(options):
       dict: Options with their original names.
     """
     org_options = {}
-    for name, value in six.iteritems(options):
+    for name, value in options.items():
         org_name = name.replace('_', '-')
         org_options[org_name] = value
     return org_options
@@ -464,7 +463,7 @@ def options_to_properties(options, name_map=None):
       dict: Resource properties (key: property name, value: option value)
     """
     properties = {}
-    for name, value in six.iteritems(options):
+    for name, value in options.items():
         if value is None:
             continue
         if name_map:
@@ -1138,7 +1137,7 @@ class ExceptionThread(threading.Thread):
         """
         super(ExceptionThread, self).join(timeout)
         if self.exc_info:
-            six.reraise(*self.exc_info)
+            raise self.exc_info.value
 
 
 def console_log(logger, prefix, message, *args, **kwargs):
@@ -1273,7 +1272,7 @@ def part_console(session, part, refresh, logger):
     while True:
         try:
             # This has history/ editing support when readline is imported
-            line = six.moves.input()
+            line = input()
         except EOFError:
             # CTRL-D was pressed
             reason = "CTRL-D"
@@ -1330,7 +1329,7 @@ def click_exception(exc, error_format):
         elif isinstance(exc, Exception):
             error_str = str(exc)
         else:
-            assert isinstance(exc, six.string_types)
+            assert isinstance(exc, str)
             error_str = "classname: None, message: {msg}".format(msg=exc)
     else:
         assert error_format == 'msg'
@@ -1338,7 +1337,7 @@ def click_exception(exc, error_format):
             error_str = "{exc}: {msg}".format(
                 exc=exc.__class__.__name__, msg=exc)
         else:
-            assert isinstance(exc, six.string_types)
+            assert isinstance(exc, str)
             error_str = exc
     new_exc = click.ClickException(error_str)
     new_exc.__cause__ = None


### PR DESCRIPTION
The special name of the branch of this PR causes the full set of Python versions to be tested against, to make sure everything works.
For details, see the commit message.
