### PR TITLE
Resolved dependency conflict with importlib-metadata on Python 3.7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -25,7 +25,8 @@ tox>=2.5.0
 
 # Virtualenv
 # build requires virtualenv.cli_run which was added in 20.1
-virtualenv>=20.1.0; python_version <= '3.11'
+# virtualenv 20.16.0 removed support for Python<3.6
+virtualenv>=20.15.0; python_version <= '3.11'
 virtualenv>=20.23.0; python_version >= '3.12'
 
 # PEP517 package builder, used in Makefile

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -91,7 +91,7 @@ six==1.16.0; python_version >= '3.10'
 tox==2.5.0
 
 # Virtualenv
-virtualenv==20.1.0; python_version <= '3.11'
+virtualenv==20.15.0; python_version <= '3.11'
 virtualenv==20.23.0; python_version >= '3.12'
 
 # PEP517 package builder, used in Makefile


### PR DESCRIPTION
For details, see the commit message.
No review needed.