### PR TITLE
1.9: Resolved dependency conflict with importlib-metadata on Python 3.7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,7 +18,9 @@ tox>=2.5.0
 # Virtualenv
 # build requires virtualenv.cli_run which was added in 20.1
 # virtualenv 20.0 requires six<2,>=1.12.0
-virtualenv>=20.1.0
+# virtualenv 20.16.0 removed support for Python<3.6
+virtualenv>=20.15.0; python_version <= '3.11'
+virtualenv>=20.23.0; python_version >= '3.12'
 
 # PEP517 package builder, used in Makefile
 build>=0.5.0

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -162,7 +162,8 @@ requests==2.31.0; python_version >= '3.7'
 tox==2.5.0
 
 # Virtualenv
-virtualenv==20.1.0
+virtualenv==20.15.0; python_version <= '3.11'
+virtualenv==20.23.0; python_version >= '3.12'
 
 # PEP517 package builder, used in Makefile
 build==0.5.0


### PR DESCRIPTION
Rolls back PR #503 into 1.9.2.
No review needed.