### PR TITLE
1.9: Fixed ruamel.yaml issue on Python 3.6 by pinning to <0.17.22

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -31,6 +31,8 @@ pep517>=0.9.1
 # Safety is run only on Python >=3.6
 safety>=2.2.0; python_version >= '3.6'
 dparse>=0.6.2; python_version >= '3.6'
+ruamel.yaml>=0.17.21,<0.17.22; python_version == '3.6'
+ruamel.yaml>=0.17.21; python_version >= '3.7'
 
 # Unit test:
 # pytest 5.0.0 has removed support for Python < 3.5

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -174,6 +174,7 @@ pep517==0.9.1
 # Safety is run only on Python >=3.6
 safety==2.2.0; python_version >= '3.6'
 dparse==0.6.2; python_version >= '3.6'
+ruamel.yaml==0.17.21; python_version >= '3.6'
 
 # Unit test (imports into testcases):
 # pytest 5.0.0 has removed support for Python < 3.5


### PR DESCRIPTION
Rolls back PR #507 into 1.9.2.