### PR TITLE
 Check in partition/lpar list that specified CPC exists 

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -139,6 +139,9 @@ Released: not yet
 * Added support for zeroizing crypto domains with a new
   command 'zhmc partition zeroize-crypto'. (issue #502)
 
+* Fail partition/lpar list commands if the specified CPC does not exist.
+  (issue #514)
+
 **Cleanup:**
 
 * Fixed copyright statements (issue #542)


### PR DESCRIPTION
Tested the following manually, on both the A224 HMC (3 CPCs in DPM mode) and on the T28 HMC (4 CPCs in classic mode):
* `zhmc partition list --names-only`  
* `zhmc partition list --names-only`    # with use of list_permitted_partitions() disabled
* `zhmc partition list A224 --names-only`
* `zhmc partition list XXX --names-only`
* `zhmc lpar list --names-only`    
* `zhmc lpar list --names-only`    # with use of list_permitted_lpars() disabled
* `zhmc lpar list T28 --names-only`
* `zhmc lpar list XXX --names-only`
