### PR TITLE
Fixed that lpar ''--defined-capacity' option takes boolean argument

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,6 +44,9 @@ Released: not yet
 
 * Fixed missing 'CPC' argument in "zhmc cpc upgrade" command. (issue #487).
 
+* Fixed that lpar ''--defined-capacity' option takes boolean argument.
+  (issue #534)
+
 **Enhancements:**
 
 * Added support for Python 3.12. Had to increase the minimum versions of

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -146,7 +146,7 @@ def lpar_show(cmd_ctx, cpc, lpar, **options):
                  'If True, z/OS Workload Manager is allowed to change '
                  'processing weight related properties of the LPAR after '
                  'activation.')
-@optgroup.option('--defined-capacity', type=bool, required=False,
+@optgroup.option('--defined-capacity', type=int, required=False,
                  help='The new defined capacity of the LPAR '
                  '(in MSU/h). This specifies how much capacity the LPAR is to '
                  'be managed to by z/OS Workload Manager for the purpose of '


### PR DESCRIPTION
No review needed.