### PR TITLE
1.9: Safety issues 2024-01-13; prompt-toolkit version

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -78,6 +78,8 @@ security:
             reason: Fixed urllib3 version 1.26.18 requires Python>=3.6 and is used there
         62044:
             reason: Fixed pip version 23.3 requires Python>=3.7 and is used there
+        62817:
+            reason: Fixed prompt-toolkit version 3.0.13 requires Python>=3.6 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Addressed safety issues up to 2024-01-13.
+
+* Increased minimum version of 'prompt-toolkit' package to 3.0.13.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -126,7 +126,8 @@ python-dateutil==2.8.2
 
 # prompt-toolkit is pulled in by click-repl.
 prompt-toolkit==1.0.15; python_version == '2.7'
-prompt-toolkit==2.0.1; python_version >= '3.5'
+prompt-toolkit==2.0.1; python_version == '3.5'
+prompt-toolkit==3.0.13; python_version >= '3.6'
 
 # PyYAML is pulled in by zhmcclient and dparse
 PyYAML==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,10 +31,10 @@ tabulate>=0.8.8; python_version >= '3.10' # MIT
 python-dateutil>=2.8.2  # Apache, BSD
 
 # prompt-toolkit is pulled in by click-repl.
-# prompt-toolkit>=2.0 conflicts with ipython and jupyter-console.
 # prompt-toolkit>=3.0 does not support py27.
-prompt-toolkit>=1.0.15,<2.0.0; python_version == '2.7'
-prompt-toolkit>=2.0.1; python_version >= '3.5'
+prompt-toolkit>=1.0.15; python_version == '2.7'
+prompt-toolkit>=2.0.1; python_version == '3.5'
+prompt-toolkit>=3.0.13; python_version >= '3.6'
 
 # PyYAML 5.3 has removed support for Python 3.4
 # PyYAML 5.3 fixed narrow build error on Python 2.7


### PR DESCRIPTION
Rolls back PR #545 to 1.9.3