### PR TITLE
[WIP] 1.9: Investigate test error on Python 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # Direct dependencies (except pip, setuptools, wheel):
 
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.10.0  # Apache
+zhmcclient>=1.10.0,<=1.13.0  # Apache
 
 # click <7.0 did not properly declare supported Python versions
 # click 8.0 has dropped support for Python 2.7,3.5


### PR DESCRIPTION
There was a test error on Python 3.5 recently in PR #556 where testcase "TestInfo.test_option_logdest" failed with a missing line in the syslog. The same failure  was reproduced in a second run:

* First run: https://github.com/zhmcclient/zhmccli/actions/runs/7765856358/job/21181018654
* Second run: https://github.com/zhmcclient/zhmccli/actions/runs/7765856358/job/21181757433

A third run succeeded, though.

The only difference in package versions between that PR #556 that failed and the last PR #549 that succeeded were:
* zhmcclient 1.13.0 -> 1.13.3
* pytz 2023.3.post1 -> 2024.1

This PR tries to reproduce the error when pinning zhmcclient to 1.13.0