### PR TITLE
Support for installation/deletion of single firmware updates on the SE 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,8 +515,9 @@ $(done_dir)/flake8_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(
 .PHONY: check_reqs
 check_reqs: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done minimum-constraints.txt requirements.txt
 	@echo "Makefile: Checking missing dependencies of this package"
-	pip-missing-reqs $(package_name) --requirements-file=requirements.txt
-	pip-missing-reqs $(package_name) --requirements-file=minimum-constraints.txt
+# TODO-ZHMC: Enable again once 1.13.4 is released
+#	pip-missing-reqs $(package_name) --requirements-file=requirements.txt
+#	pip-missing-reqs $(package_name) --requirements-file=minimum-constraints.txt
 	@echo "Makefile: Done checking missing dependencies of this package"
 ifeq ($(PLATFORM),Windows_native)
 # Reason for skipping on Windows is https://github.com/r1chardj0n3s/pip-check-reqs/issues/67

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -77,8 +77,8 @@ Released: not yet
   commands have been grouped to be more easily identifiable. This required
   adding the "click-option-group" Python package to the dependencies.
 
-* Increased minimum zhmcclient version to 1.12.1 to pick up fixes and
-  functionality. (issue #510)
+* Increased minimum zhmcclient version to 1.13.3 to pick up fixes and
+  functionality. (issues #510, #528)
 
 * Tests: Added an environment variable TESTLOG to enable logging for end2end
   tests. (issue #414)
@@ -117,6 +117,12 @@ Released: not yet
 
 * Added support for user patterns with a new 'zhmc userpattern' command group.
   (issue #550)
+
+* Added support for installation of single firmware updates on the SE with a
+  new 'zhmc cpc install-firmware' command. (issue #528)
+
+* Added support for deletion of uninstalled firmware updates from the SE with a
+  new 'zhmc cpc delete-uninstalled-firmware' command. (issue #528)
 
 **Cleanup:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -38,7 +38,8 @@ wheel==0.38.1; python_version >= '3.7'
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
 
-zhmcclient==1.12.1
+# TODO-ZHMC: Enable again once 1.13.4 is released
+# zhmcclient==1.13.4
 
 click==8.0.2
 click-repl==0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,9 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-# zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.12.1
+# TODO-ZHMC: Enable again once 1.13.4 is released
+zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@stable_1.13
+# zhmcclient>=1.13.4
 
 # safety 2.2.0 depends on click>=8.0.2
 click>=8.0.2

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -1754,6 +1754,27 @@ def get_level_str(bundle_level, ftp_host):
     return level_str
 
 
+def get_mcl_str(bundle_level, ec_levels, all_, concurrent, install_disruptive):
+    """
+    Get a string for messages about the MCLs to be installed.
+    """
+    if install_disruptive:
+        dis_str = " (including disruptive MCLs)"
+    else:
+        dis_str = " (disruptive MCLs will fail)"
+    if bundle_level is not None:
+        mcl_str = "bundle level {bl}".format(bl=bundle_level)
+    elif ec_levels is not None:
+        mcl_str = "EC levels {el}".format(el=ec_levels)
+    elif all_:
+        mcl_str = "all locally available MCLs"
+    else:
+        assert concurrent
+        mcl_str = "all locally available non-disruptive MCLs"
+        dis_str = ""
+    return mcl_str, dis_str
+
+
 def parse_yaml_flow_style(cmd_ctx, option_name, value):
     """
     Parse an option value that is a string in YAML Flow Collection Style.


### PR DESCRIPTION
For details, see the commit message.

Particular review points:
* Do the options to select firmware updates in the new "zhmc cpc install-firmware" command make sense
* Name of the new commands  "zhmc cpc install-firmware" and "zhmc cpc delete-uninstalled-firmware", particularly compared to "zhmc cpc upgrade"