### PR TITLE
1.9: Fixed call to pipdeptree in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
       run: |
         echo "Package dependency tree of installed Python packages:"
-        pipdeptree --all
+        python -m pipdeptree --all
     - name: Run check_reqs
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -52,6 +52,10 @@ Released: not yet
   users. In addition, omitted 'min-pw-change-time' for non-local users.
   (issue #557)
 
+* Fixed the call to pipdeptree in the test workflow to use 'python -m'
+  because otherwise it does not show the correct packages of the virtual env.
+  (issue #539)
+
 **Enhancements:**
 
 * Test: Added Python 3.8 with latest package levels to normal tests because


### PR DESCRIPTION
Rolls back PR #573 into 1.9.3.