### PR TITLE
Fixed check_reqs SyntaxWarning on tox by increasing tox to 3.1.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -21,7 +21,7 @@ six>=1.14.0; python_version <= '3.9'
 six>=1.16.0; python_version >= '3.10'
 
 # Tox
-tox>=2.5.0
+tox>=3.1.0
 
 # Virtualenv
 # build requires virtualenv.cli_run which was added in 20.1

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -88,7 +88,7 @@ six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
 
 # Tox
-tox==2.5.0
+tox==3.1.0
 
 # Virtualenv
 virtualenv==20.15.0; python_version <= '3.11'


### PR DESCRIPTION
No review needed.