### PR TITLE
Avoid pull_full_properties() in print_resources_as_table

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,10 @@ Released: not yet
 * The safety run for all dependencies now must succeed when the test workflow
   is run for a release (i.e. branch name 'release_...').
 
+* Improved performance of 'list' commands by pulling only the properties
+  needed for the output, instead of all of them. This reduced the time to list
+  CPCs from over 20 seconds to under 1 second on a test system.
+
 **Cleanup:**
 
 **Known issues:**

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -725,13 +725,20 @@ def print_resources_as_table(
     for resource in resources:
         resource_props = {}
         if show_list:
+            props_to_query = []
             for name in show_list:
                 if additions and name in additions:
-                    value = additions[name][resource.uri]
+                    resource_props[name] = additions[name][resource.uri]
+                    prop_names[name] = None
                 else:
-                    # May raise zhmcclient exceptions
-                    value = resource.prop(name)
-                resource_props[name] = value
+                    props_to_query.append(name)
+            # Pull selected properties into cache in one call.
+            # Resource.prop() calls pull_full_properties if the value is
+            # not cached which is expensive for certain properties.
+            resource.pull_properties(props_to_query)
+            for name in props_to_query:
+                # May raise zhmcclient exceptions
+                resource_props[name] = resource.prop(name)
                 prop_names[name] = None
         else:
             for name in sorted(resource.properties):


### PR DESCRIPTION
This improves performance in cases where pull_full_properties contains properties that are expensive to query but are not needed in the table.

Reduces time to list CPCs from over 20 seconds to under 1 second on my test system.