### PR TITLE
1.10: Fixed macos version used in test workflow for py36/37

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,26 @@ jobs:
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"latest\" \
               } \
             ], \
             \"include\": [ \
@@ -58,6 +78,26 @@ jobs:
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.7\", \
                 \"package_level\": \"latest\" \
               } \
             ] \
@@ -74,17 +114,27 @@ jobs:
                 \"package_level\": \"minimum\" \
               }, \
               { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.7\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
                 \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.8\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.8\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
                 \"python-version\": \"3.8\", \
                 \"package_level\": \"latest\" \
               }, \

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* In the Github Actions test workflow for Python 3.5, 3.6 and 3.7, changed
+  macos-latest back to macos-12 because macos-latest got upgraded from macOS 12
+  to macOS 14 which no longer supports these Python versions.
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #599 into 1.10.1.