### PR TITLE
1.10: Fix cpc-name handling for cpc autostart add

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -35,6 +35,8 @@ Released: not yet
   macos-latest back to macos-12 because macos-latest got upgraded from macOS 12
   to macOS 14 which no longer supports these Python versions.
 
+* Fixed an error in the 'cpc autostart add' command.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -1149,14 +1149,15 @@ def cmd_cpc_autostart_add(cmd_ctx, cpc_name, partitions_delay, options):
         partition_names = partition_names.split(',')
         partitions = []
         for partition_name in partition_names:
-            partition = find_partition(cmd_ctx, client, cpc, partition_name)
+            partition = find_partition(cmd_ctx, client, cpc_name,
+                                       partition_name)
             partitions.append(partition)
         description = options['description']
         new_as_item = (partitions, group_name, description, delay)
     else:
         # A partition is added
         partition_name = partition_names
-        partition = find_partition(cmd_ctx, client, cpc, partition_name)
+        partition = find_partition(cmd_ctx, client, cpc_name, partition_name)
         new_as_item = (partition, delay)
 
     # TODO: Add support for --before and --after


### PR DESCRIPTION
Rolls back PR #598 into 1.10.1.