### PR TITLE
Increased minimum version of zhmcclient to 1.17.0

### DIFF
--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -30,12 +30,6 @@ security:
             reason: Fixed version PyYAML 5.4.0 (and 6.0.0) fails to install since Cython 3 was released; No risk since full_load method and FullLoader are not used
         67599:
             reason: There is no fixed pip version
-        67884:
-            # TODO: Adjust once we remove stomp-py pinning
-            reason: Fixed stomp-py version 8.1.1 conflicts with our pinning of stomp-py to <7.0.0
-        67894:
-            # TODO: Adjust once we remove stomp-py pinning
-            reason: Fixed stomp-py version 8.1.1 conflicts with our pinning of stomp-py to <7.0.0
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,9 @@ Released: not yet
 
 * Addressed safety issues up to 2024-07-21.
 
+* Increased minimum version of zhmcclient to 1.17.0 (and dependent packages
+  accordingly) to pick up fixes and functionality. (issue #623)
+
 **Enhancements:**
 
 * Test: Added support for running the 'ruff' checker via "make ruff" and added

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -12,7 +12,7 @@ wheel==0.38.1
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-zhmcclient==1.13.4
+zhmcclient==1.17.0
 
 click==8.0.2
 click-repl==0.2
@@ -30,7 +30,7 @@ prompt-toolkit==3.0.13
 # PyYAML is pulled in by zhmccli, zhmcclient, yamlloader
 PyYAML==5.3.1
 
-jsonschema==3.0.1
+jsonschema==3.1.0
 yamlloader==0.5.5
 
 # urllib3 is used to disable warnings
@@ -52,6 +52,6 @@ docopt==0.6.2
 idna==3.7
 python-utils==2.0.1
 pytz==2019.1
-stomp.py==4.1.23
+stomp-py==8.1.1
 wcwidth==0.2.6
 requests==2.32.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@
 
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
-# zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@stable_1.13
-zhmcclient>=1.13.4
+# zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
+zhmcclient>=1.17.0
 
 # safety 2.2.0 depends on click>=8.0.2
 click>=8.0.2
@@ -35,7 +35,7 @@ prompt-toolkit>=3.0.13
 PyYAML>=5.3.1,!=5.4.0,!=5.4.1; python_version <= '3.11'
 PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
 
-jsonschema>=3.0.1
+jsonschema>=3.1.0
 yamlloader>=0.5.5
 
 urllib3>=1.26.19


### PR DESCRIPTION
No review needed.
Cannot be rolled back to 1.10.x because of the requirement for Python>=3.8.