### PR TITLE
1.12: Fixed AttributeError when ending interactive LPAR console session

### DIFF
--- a/changes/676.fix.rst
+++ b/changes/676.fix.rst
@@ -1,0 +1,2 @@
+Fixed the AttributeError exception that occurred when ending an interactive
+LPAR console session.

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -1144,7 +1144,7 @@ class ExceptionThread(threading.Thread):
         """
         super().join(timeout)
         if self.exc_info:
-            raise self.exc_info.value
+            raise self.exc_info[1]
 
 
 def console_log(logger, prefix, message, *args, **kwargs):


### PR DESCRIPTION
Rolls back PR #677 into 1.12.1.