### PR TITLE
1.12: Safety issues up to 2025-01-12

### DIFF
--- a/changes/noissue.safety.fix.rst
+++ b/changes/noissue.safety.fix.rst
@@ -1,0 +1,1 @@
+Addressed safety issues up to 2025-01-12.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -12,7 +12,7 @@ wheel==0.41.3
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-zhmcclient==1.18.0
+zhmcclient==1.18.2
 
 click==8.0.2
 click-repl==0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.18.0
+zhmcclient>=1.18.2
 
 # safety 2.2.0 depends on click>=8.0.2
 click>=8.0.2


### PR DESCRIPTION
No review needed.
In the master branch, zhmcclient is already at 1.19.0, so no separate PR needed for this change here.,