### PR TITLE
1.12: Fixed missing package dependencies for development (nltk)

### DIFF
--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -125,6 +125,7 @@ keyring==17.0.0
 levenshtein==0.25.1
 MarkupSafe==2.0.0
 more-itertools==5.0.0
+nltk==3.9
 pyparsing==3.0.7
 pyproject-api==1.6.1  # used by tox since its 4.0.0
 requests-toolbelt==0.8.0


### PR DESCRIPTION
Rolls back PR #702 into 1.12. No review needed.