### PR TITLE
1.12: Started using the trusted publisher concept of Pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,14 @@ jobs:
     name: Build and publish to PyPI
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    # This workflow uses Pypi trusted publishing, see https://docs.pypi.org/trusted-publishers/
+    # Requirements:
+    # - On the Pypi project, the GitHub repo must be defined as a trusted publisher
+    # - On the GitHub repo, an environment 'pypi' must exist
+    environment: pypi  # For Pypi trusted publishing
+    permissions:
+      id-token: write  # For Pypi trusted publishing
+      contents: write  # For creating GitHub release
     steps:
 
     #-------- Info gathering and checks
@@ -142,7 +150,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: dist
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        # Pypi trusted publishing allows to have no password
 
     #-------- Creation of Github release
     - name: Determine whether release on Github exists for the pushed tag

--- a/changes/712.feature.rst
+++ b/changes/712.feature.rst
@@ -1,0 +1,2 @@
+Dev: Started using the trusted publisher concept of Pypi in order to avoid
+dealing with Pypi access tokens.


### PR DESCRIPTION
Rolls back PR #712 into 1.12.