### PR TITLE
1.12: Increased safety to 3.4.0 and updated its dependencies; Safety issues

### DIFF
--- a/changes/noissue.safety.fix.rst
+++ b/changes/noissue.safety.fix.rst
@@ -1,1 +1,1 @@
-Addressed safety issues up to 2025-02-26.
+Addressed safety issues up to 2025-04-24.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,22 +23,22 @@ pyproject-hooks>=1.1.0
 towncrier>=22.8.0
 
 # Safety CI by pyup.io
-# Safety 3.0.0 requires exact versions of authlib==1.2.0 and jwt==1.3.1.
-# Safety 3.0.x pins pydantic to <2.0, preventing bug fixes.
+# safety 3.4.0 supports marshmallow>=4.0.0, see https://github.com/pyupio/safety/issues/715
+# safety 3.4.0 started using httpx and tenacity
 # pydantic 2.8.0 fixes an install issue on Python 3.13.
-safety>=3.1.0
-safety-schemas>=0.0.2,!=0.0.7
-# TODO: Change to dparse 0.6.4 once released
-dparse>=0.6.4b0
+safety>=3.4.0
+safety-schemas>=0.0.14
+dparse>=0.6.4
 ruamel.yaml>=0.17.21
 # click is covered in requirements.txt
-Authlib>=1.2.0
+Authlib>=1.3.1
 marshmallow>=3.15.0
 pydantic>=2.8.0
-typer>=0.12.0
-typer-cli>=0.12.0
-typer-slim>=0.12.0
-psutil>=6.0.0
+typer>=0.12.1
+typer-cli>=0.12.1
+typer-slim>=0.12.1
+# safety 3.4.0 depends on psutil~=6.1.0
+psutil~=6.1.0
 
 # Bandit checker
 bandit>=1.7.8

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -22,19 +22,18 @@ incremental==22.10.0
 click-default-group==1.2.4
 
 # Safety CI by pyup.io
-safety==3.1.0
-safety-schemas==0.0.2
-# TODO: Change to dparse 0.6.4 once released
-dparse==0.6.4b0
+safety==3.4.0
+safety-schemas==0.0.14
+dparse==0.6.4
 ruamel.yaml==0.17.21
 # click is covered in requirements.txt
 Authlib==1.3.1
 marshmallow==3.15.0
 pydantic==2.8.0
-typer==0.12.0
-typer-cli==0.12.0
-typer-slim==0.12.0
-psutil==6.0.0
+typer==0.12.1
+typer-cli==0.12.1
+typer-slim==0.12.1
+psutil==6.1.0
 
 # Bandit checker
 bandit==1.7.8
@@ -114,13 +113,15 @@ clint==0.5.1
 configparser==4.0.2
 contextlib2==0.6.0
 distlib==0.3.7
-filelock==3.13.1
+# safety 3.4.0 depends on filelock~=3.16.1
+filelock==3.16.1
 gitdb2==2.0.0
 gitdb==4.0.8
+httpx==0.28.1
 imagesize==1.3.0
 importlib-resources==1.4.0
 iniconfig==2.0.0  # used by pytest since its 6.0.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 keyring==17.0.0
 levenshtein==0.25.1
 MarkupSafe==2.0.0
@@ -134,6 +135,7 @@ roman-numerals-py==1.0.0; python_version >= '3.9'  # used by Sphinx>=8.2.0
 smmap==3.0.1
 snowballstemmer==2.0.0
 stevedore==5.2.0
+tenacity==8.5.0
 toml==0.10.0  # used by pylint and pytest since some version
 tomli==2.0.1
 tqdm==4.66.3


### PR DESCRIPTION
Rolls back PR #737 into 1.12.