### PR TITLE
Show candidate adapter names in 'storagegroup show'

### DIFF
--- a/changes/739.fix.rst
+++ b/changes/739.fix.rst
@@ -1,0 +1,4 @@
+Fixed the values for the artificial property "candidate-adapter-port-names"
+in the output of the "zhmc storagegroup show" command. So far, it showed
+only the port name, which was not very helpful. Now, it shows adapter name
+and port name.


### PR DESCRIPTION
For details, see the commit message.

Tested manually on T224.

Before:
```
$ zhmc storagegroup show pok-ahps-iep-rhel-01
+------------------------------+--------------------------------------------------------------------+
| Field Name                   | Value                                                              |
|------------------------------+--------------------------------------------------------------------|
| candidate-adapter-port-names | Port 0                                                             |
|                              | Port 0                                                             |
|                              | Port 0                                                             |
|                              | Port 0                                                             |
|                              | Port 0                                                             |
| candidate-adapter-port-uris  | /api/adapters/18dd8152-21dc-11f0-931e-00106f271ac2/storage-ports/0 |
|                              | /api/adapters/18b0603c-21dc-11f0-931e-00106f271ac2/storage-ports/0 |
|                              | /api/adapters/1980f526-21dc-11f0-931e-00106f271ac2/storage-ports/0 |
|                              | /api/adapters/1f414f10-21dc-11f0-931e-00106f271ac2/storage-ports/0 |
|                              | /api/adapters/1f1d7c02-21dc-11f0-931e-00106f271ac2/storage-ports/0 |
```

After:
```
$ zhmc storagegroup show pok-ahps-iep-rhel-01
+------------------------------+--------------------------------------------------------------------+
| Field Name                   | Value                                                              |
|------------------------------+--------------------------------------------------------------------|
| candidate-adapter-port-names | FCP 0160 B33B-12 / Port 0                                          |
|                              | FCP 0125 A31B-13 / Port 0                                          |
|                              | FCP 0124 A31B-13 / Port 0                                          |
|                              | FCP 0101 A31B-02 / Port 0                                          |
|                              | FCP 0144 B33B-03 / Port 0                                          |
| candidate-adapter-port-uris  | /api/adapters/18dd8152-21dc-11f0-931e-00106f271ac2/storage-ports/0 |
|                              | /api/adapters/18b0603c-21dc-11f0-931e-00106f271ac2/storage-ports/0 |
|                              | /api/adapters/1980f526-21dc-11f0-931e-00106f271ac2/storage-ports/0 |
|                              | /api/adapters/1f414f10-21dc-11f0-931e-00106f271ac2/storage-ports/0 |
|                              | /api/adapters/1f1d7c02-21dc-11f0-931e-00106f271ac2/storage-ports/0 |
```
