### PR TITLE
1.12: Show candidate adapter names in 'storagegroup show'

### DIFF
--- a/changes/739.fix.rst
+++ b/changes/739.fix.rst
@@ -1,0 +1,4 @@
+Fixed the values for the artificial property "candidate-adapter-port-names"
+in the output of the "zhmc storagegroup show" command. So far, it showed
+only the port name, which was not very helpful. Now, it shows adapter name
+and port name.


### PR DESCRIPTION
Rolls back PR #740 into 1.12.