### PR TITLE
Fixed and enhanced --port option of multiple commands

### DIFF
--- a/changes/747.feature.rst
+++ b/changes/747.feature.rst
@@ -1,0 +1,4 @@
+Added support for specifying the adapter port as port index as an additional
+alternative to the port name, in the '--port' option of multiple commands:
+'zhmc storagegroup add-ports', 'zhmc storagegroup remove-ports',
+'zhmc vstorageresource update', 'zhmc storagevolume fulfill-fcp'.

--- a/changes/747.fix.rst
+++ b/changes/747.fix.rst
@@ -1,0 +1,4 @@
+Fixed the handling of the '--port' option that resulted in an error, in
+multiple commands: 'zhmc storagegroup add-ports',
+'zhmc storagegroup remove-ports', 'zhmc vstorageresource update',
+'zhmc storagevolume fulfill-fcp'.

--- a/zhmccli/_cmd_nic.py
+++ b/zhmccli/_cmd_nic.py
@@ -112,7 +112,7 @@ def nic_show(cmd_ctx, cpc, partition, nic):
 @click.option('--adapter', type=str, required=False,
               help='The name of the network adapter with the port backing the '
               'new NIC. Required.')
-@click.option('--port', type=str, required=False,
+@click.option('--port', type=str, metavar='NAME|INDEX', required=False,
               help='The name or index of the network port backing the new NIC. '
               'Required.')
 @click.option('--virtual-switch', type=str, required=False,
@@ -181,7 +181,7 @@ def nic_create(cmd_ctx, cpc, partition, **options):
 @click.option('--adapter', type=str, required=False,
               help='The name of the network adapter with the port backing the '
               'NIC. Required.')
-@click.option('--port', type=str, required=False,
+@click.option('--port', type=str, metavar='NAME|INDEX', required=False,
               help='The name or index of the network port backing the NIC. '
               'Required.')
 @click.option('--virtual-switch', type=str, required=False,

--- a/zhmccli/_cmd_port.py
+++ b/zhmccli/_cmd_port.py
@@ -29,11 +29,18 @@ from ._cmd_adapter import find_adapter
 
 def find_port(cmd_ctx, client, cpc_name, adapter_name, port_name):
     """
-    Find a port by name and return its resource object.
+    Find a port by name or index and return its resource object.
     """
     adapter = find_adapter(cmd_ctx, client, cpc_name, adapter_name)
     try:
-        port = adapter.ports.find(name=port_name)
+        port_index = int(port_name)
+    except ValueError:
+        port_index = None
+    try:
+        if port_index is None:
+            port = adapter.ports.find(name=port_name)
+        else:
+            port = adapter.ports.find(index=port_index)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
     return port

--- a/zhmccli/_cmd_storagegroup.py
+++ b/zhmccli/_cmd_storagegroup.py
@@ -289,9 +289,9 @@ def storagegroup_list_ports(cmd_ctx, storagegroup):
               'added. '
               'The --adapter and --port options can be specified multiple '
               'times and correspond to each other via their order.')
-@click.option('--port', type=str, metavar='NAME',
+@click.option('--port', type=str, metavar='NAME|INDEX',
               required=False, multiple=True,
-              help='The name of the storage adapter port to be added. '
+              help='The name or index of the storage adapter port to be added. '
               'The --adapter and --port options can be specified multiple '
               'times and correspond to each other via their order.')
 @click.pass_obj
@@ -317,9 +317,9 @@ def storagegroup_add_ports(cmd_ctx, storagegroup, **options):
               'added. '
               'The --adapter and --port options can be specified multiple '
               'times and correspond to each other via their order.')
-@click.option('--port', type=str, metavar='NAME',
+@click.option('--port', type=str, metavar='NAME|INDEX',
               required=False, multiple=True,
-              help='The name of the storage adapter port to be added. '
+              help='The name or index of the storage adapter port to be added. '
               'The --adapter and --port options can be specified multiple '
               'times and correspond to each other via their order.')
 @click.pass_obj
@@ -683,7 +683,7 @@ def cmd_storagegroup_add_ports(cmd_ctx, stogrp_name, options):
     ports = []
     for i, adapter_name in enumerate(adapter_names):
         port_name = port_names[i]
-        port = find_port(cmd_ctx, client, cpc, adapter_name, port_name)
+        port = find_port(cmd_ctx, client, cpc.name, adapter_name, port_name)
         ports.append(port)
 
     if not ports:
@@ -720,7 +720,7 @@ def cmd_storagegroup_remove_ports(cmd_ctx, stogrp_name, options):
     ports = []
     for i, adapter_name in enumerate(adapter_names):
         port_name = port_names[i]
-        port = find_port(cmd_ctx, client, cpc, adapter_name, port_name)
+        port = find_port(cmd_ctx, client, cpc.name, adapter_name, port_name)
         ports.append(port)
 
     if not ports:

--- a/zhmccli/_cmd_storagevolume.py
+++ b/zhmccli/_cmd_storagevolume.py
@@ -247,9 +247,9 @@ def storagevolume_delete(cmd_ctx, storagegroup, storagevolume, **options):
 @click.option('--adapter', type=str, metavar='NAME', required=True,
               help='The name of the storage adapter that has the port used to '
               'boot from the storage volume.')
-@click.option('--port', type=str, metavar='NAME', required=True,
-              help='The name of the storage adapter port used to boot from the '
-              'storage volume.')
+@click.option('--port', type=str, metavar='NAME|INDEX', required=True,
+              help='The name or index of the storage adapter port used to boot '
+              'from the storage volume.')
 @click.pass_obj
 def storagevolume_fulfill_fcp(cmd_ctx, storagegroup, storagevolume, **options):
     """
@@ -452,7 +452,7 @@ def cmd_storagevolume_fulfill_fcp(cmd_ctx, stogrp_name, stovol_name, options):
     adapter_name = options['adapter']
     port_name = options['port']
 
-    port = find_port(cmd_ctx, client, cpc, adapter_name, port_name)
+    port = find_port(cmd_ctx, client, cpc.name, adapter_name, port_name)
 
     try:
         stovol.indicate_fulfillment_fcp(wwpn, lun, port)

--- a/zhmccli/_cmd_vstorageresource.py
+++ b/zhmccli/_cmd_vstorageresource.py
@@ -119,9 +119,9 @@ def vstorageresource_show(cmd_ctx, storagegroup, vstorageresource):
 @click.option('--adapter', type=str, metavar='NAME', required=False,
               help='The name of the storage adapter with the new port to which '
               'the virtual storage resource will be associated.')
-@click.option('--port', type=str, metavar='NAME', required=False,
-              help='The name of the new storage adapter port to which the '
-              'virtual storage resource will be associated.')
+@click.option('--port', type=str, metavar='NAME|INDEX', required=False,
+              help='The name or index of the new storage adapter port to which '
+              'the virtual storage resource will be associated.')
 @click.option('--device-number', type=str, required=False,
               help='A four-byte lower case hexadecimal string defining the '
               'new device number used for the volume when the FICON '
@@ -285,7 +285,7 @@ def cmd_vstorageresource_update(cmd_ctx, stogrp_name, vsr_name, options):
             "The --adapter and --port options must be specified together.",
             cmd_ctx.error_format)
     if adapter_name:
-        port = find_port(cmd_ctx, client, cpc, adapter_name, port_name)
+        port = find_port(cmd_ctx, client, cpc.name, adapter_name, port_name)
         properties['adapter-port-uri'] = port.uri
 
     if not properties:


### PR DESCRIPTION
For details, see the commit message.

I tested the change manually with the "storagegroup add/remove-port" commands on the AHPS system.