### PR TITLE
Added support for filtering list output by property values

### DIFF
--- a/changes/752.feature.rst
+++ b/changes/752.feature.rst
@@ -1,0 +1,2 @@
+Added support for filtering list output by property values, by adding a new
+`--filter PROP=VALIUE,...` option to all `list` commands.

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -26,8 +26,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS, domain_config_to_props_list, \
-    print_dicts
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, domain_config_to_props_list, print_dicts
 from ._cmd_cpc import find_cpc
 
 
@@ -91,6 +91,7 @@ def adapter_group():
 @click.argument('CPC', type=str, metavar='CPC')
 @click.option('--type', is_flag=True, required=False, hidden=True)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def adapter_list(cmd_ctx, cpc, **options):
     """
@@ -276,8 +277,9 @@ def cmd_adapter_list(cmd_ctx, cpc_name, options):
     client = zhmcclient.Client(cmd_ctx.session)
     cpc = find_cpc(cmd_ctx, client, cpc_name)
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        adapters = cpc.adapters.list()
+        adapters = cpc.adapters.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_capacitygroup.py
+++ b/zhmccli/_cmd_capacitygroup.py
@@ -23,7 +23,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args
 from ._cmd_cpc import find_cpc
 from ._cmd_partition import find_partition
 
@@ -66,6 +67,7 @@ def capacitygroup_group():
 @capacitygroup_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def capacitygroup_list(cmd_ctx, cpc, **options):
     """
@@ -245,8 +247,9 @@ def cmd_capacitygroup_list(cmd_ctx, cpc_name, options):
     client = zhmcclient.Client(cmd_ctx.session)
     cpc = find_cpc(cmd_ctx, client, cpc_name)
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        capacitygroups = cpc.capacity_groups.list()
+        capacitygroups = cpc.capacity_groups.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_certificates.py
+++ b/zhmccli/_cmd_certificates.py
@@ -22,8 +22,8 @@ import click
 import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
-    options_to_properties, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS
+    options_to_properties, COMMAND_OPTIONS_METAVAR, click_exception, \
+    add_options, LIST_OPTIONS, FILTER_OPTIONS, build_filter_args
 
 
 def find_certificate(cmd_ctx, client, cert_name):
@@ -94,6 +94,7 @@ def certificate_delete(cmd_ctx, certificate, **options):
 
 @certificate_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def certificate_list(cmd_ctx, **options):
     """
@@ -194,8 +195,9 @@ def cmd_certificate_list(cmd_ctx, options):
     client = zhmcclient.Client(cmd_ctx.session)
     console = client.consoles.console
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        certificates = console.certificates.list()
+        certificates = console.certificates.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -28,8 +28,9 @@ from tabulate import tabulate
 
 from ._helper import print_properties, print_resources, print_list, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS, TABLE_FORMATS, hide_property, \
-    required_option, validate, print_dicts, get_level_str, \
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, TABLE_FORMATS, \
+    hide_property, required_option, validate, print_dicts, get_level_str, \
     prompt_ftp_password, convert_ec_mcl_description, get_mcl_str, \
     parse_ec_levels, parse_timestamp, TIMESTAMP_BEGIN_DEFAULT, \
     TIMESTAMP_END_DEFAULT
@@ -196,6 +197,7 @@ def cpc_group():
 @click.option('--type', is_flag=True, required=False, hidden=True)
 @click.option('--mach', is_flag=True, required=False, hidden=True)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def cpc_list(cmd_ctx, **options):
     """
@@ -933,8 +935,9 @@ def cmd_cpc_list(cmd_ctx, options):
 
     client = zhmcclient.Client(cmd_ctx.session)
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        cpcs = client.cpcs.list()
+        cpcs = client.cpcs.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_hba.py
+++ b/zhmccli/_cmd_hba.py
@@ -23,7 +23,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args
 from ._cmd_partition import find_partition
 
 
@@ -57,6 +58,7 @@ def hba_group():
 @click.argument('CPC', type=str, metavar='CPC')
 @click.argument('PARTITION', type=str, metavar='PARTITION')
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def hba_list(cmd_ctx, cpc, partition, **options):
     """
@@ -170,11 +172,12 @@ def cmd_hba_list(cmd_ctx, cpc_name, partition_name, options):
     client = zhmcclient.Client(cmd_ctx.session)
     partition = find_partition(cmd_ctx, client, cpc_name, partition_name)
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     if partition.hbas is None:
         hbas = []
     else:
         try:
-            hbas = partition.hbas.list()
+            hbas = partition.hbas.list(filter_args=filter_args)
         except zhmcclient.Error as exc:
             raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_imageprofile.py
+++ b/zhmccli/_cmd_imageprofile.py
@@ -24,8 +24,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS, str2int, \
-    absolute_capping_value, parse_yaml_flow_style
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, str2int, absolute_capping_value, parse_yaml_flow_style
 from ._cmd_cpc import find_cpc
 from ._cmd_certificates import find_certificate
 
@@ -69,6 +69,7 @@ def imageprofile_group():
 @imageprofile_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('cpc', type=str, metavar='[CPC]', required=False)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def imageprofile_list(cmd_ctx, cpc, **options):
     """
@@ -1568,12 +1569,15 @@ def cmd_imageprofile_list(cmd_ctx, cpc_name, options):
             'element-uri',
         ])
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     imageprofiles = []
     for cpc in cpcs:
         try:
-            imageprofiles.extend(cpc.image_activation_profiles.list())
+            ip_list = cpc.image_activation_profiles.list(
+                filter_args=filter_args)
         except zhmcclient.Error as exc:
             raise click_exception(exc, cmd_ctx.error_format)
+        imageprofiles.extend(ip_list)
 
         for imageprofile in imageprofiles:
             cpc = imageprofile.manager.parent

--- a/zhmccli/_cmd_ldap_server_definition.py
+++ b/zhmccli/_cmd_ldap_server_definition.py
@@ -23,7 +23,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args
 
 
 def find_ldapdef(cmd_ctx, console, ldapdef_name):
@@ -51,6 +52,7 @@ def ldapdef_group():
 
 @ldapdef_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def ldapdef_list(cmd_ctx, **options):
     """
@@ -245,9 +247,10 @@ def cmd_ldapdef_list(cmd_ctx, options):
 
     additions = {}
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
         ldapdefs = console.ldap_server_definitions.list(
-            full_properties=False)
+            full_properties=False, filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_loadprofile.py
+++ b/zhmccli/_cmd_loadprofile.py
@@ -24,7 +24,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS, str2int
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, str2int
 from ._cmd_cpc import find_cpc
 
 
@@ -66,6 +67,7 @@ def loadprofile_group():
 @loadprofile_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('cpc', type=str, metavar='[CPC]', required=False)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def loadprofile_list(cmd_ctx, cpc, **options):
     """
@@ -452,12 +454,14 @@ def cmd_loadprofile_list(cmd_ctx, cpc_name, options):
             'element-uri',
         ])
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     loadprofiles = []
     for cpc in cpcs:
         try:
-            loadprofiles.extend(cpc.load_activation_profiles.list())
+            lp_list = cpc.load_activation_profiles.list(filter_args=filter_args)
         except zhmcclient.Error as exc:
             raise click_exception(exc, cmd_ctx.error_format)
+        loadprofiles.extend(lp_list)
 
         for loadprofile in loadprofiles:
             cpc = loadprofile.manager.parent

--- a/zhmccli/_cmd_nic.py
+++ b/zhmccli/_cmd_nic.py
@@ -23,7 +23,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args
 from ._cmd_partition import find_partition
 from ._cmd_cpc import find_cpc
 
@@ -63,6 +64,7 @@ def nic_group():
 @click.argument('PARTITION', type=str, metavar='PARTITION')
 @click.option('--type', is_flag=True, required=False, hidden=True)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def nic_list(cmd_ctx, cpc, partition, **options):
     """
@@ -370,8 +372,9 @@ def cmd_nic_list(cmd_ctx, cpc_name, partition_name, options):
     client = zhmcclient.Client(cmd_ctx.session)
     partition = find_partition(cmd_ctx, client, cpc_name, partition_name)
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        nics = partition.nics.list()
+        nics = partition.nics.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_password_rule.py
+++ b/zhmccli/_cmd_password_rule.py
@@ -23,7 +23,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args
 
 
 def find_password_rule(cmd_ctx, console, password_rule_name):
@@ -50,6 +51,7 @@ def password_rule_group():
 
 @password_rule_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def password_rule_list(cmd_ctx, **options):
     """
@@ -219,8 +221,10 @@ def cmd_password_rule_list(cmd_ctx, options):
 
     additions = {}
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        password_rules = console.password_rules.list(full_properties=False)
+        password_rules = console.password_rules.list(
+            full_properties=False, filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_port.py
+++ b/zhmccli/_cmd_port.py
@@ -23,7 +23,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args
 from ._cmd_adapter import find_adapter
 
 
@@ -63,6 +64,7 @@ def port_group():
 @click.argument('CPC', type=str, metavar='CPC')
 @click.argument('ADAPTER', type=str, metavar='ADAPTER')
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def port_list(cmd_ctx, cpc, adapter, **options):
     """
@@ -127,8 +129,10 @@ def cmd_port_list(cmd_ctx, cpc_name, adapter_name, options):
     client = zhmcclient.Client(cmd_ctx.session)
     adapter = find_adapter(cmd_ctx, client, cpc_name, adapter_name)
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        ports = adapter.ports.list(full_properties=True)
+        ports = adapter.ports.list(
+            full_properties=True, filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_resetprofile.py
+++ b/zhmccli/_cmd_resetprofile.py
@@ -24,7 +24,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS, str2int, parse_yaml_flow_style
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, str2int, parse_yaml_flow_style
 from ._cmd_cpc import find_cpc
 
 
@@ -67,6 +68,7 @@ def resetprofile_group():
 @resetprofile_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('cpc', type=str, metavar='[CPC]', required=False)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def resetprofile_list(cmd_ctx, cpc, **options):
     """
@@ -284,12 +286,15 @@ def cmd_resetprofile_list(cmd_ctx, cpc_name, options):
             'element-uri',
         ])
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     resetprofiles = []
     for cpc in cpcs:
         try:
-            resetprofiles.extend(cpc.reset_activation_profiles.list())
+            rp_list = cpc.reset_activation_profiles.list(
+                filter_args=filter_args)
         except zhmcclient.Error as exc:
             raise click_exception(exc, cmd_ctx.error_format)
+        resetprofiles.extend(rp_list)
 
         for resetprofile in resetprofiles:
             cpc = resetprofile.manager.parent

--- a/zhmccli/_cmd_storagegroup.py
+++ b/zhmccli/_cmd_storagegroup.py
@@ -25,8 +25,8 @@ from ._cmd_cpc import find_cpc
 from ._cmd_port import find_port
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS, EMAIL_OPTIONS, \
-    ASYNC_TIMEOUT_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, EMAIL_OPTIONS, ASYNC_TIMEOUT_OPTIONS
 
 
 ALL_TYPES = ['fcp', 'fc']
@@ -82,6 +82,7 @@ def storagegroup_group():
 
 @storagegroup_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def storagegroup_list(cmd_ctx, **options):
     """
@@ -364,8 +365,9 @@ def cmd_storagegroup_list(cmd_ctx, options):
     client = zhmcclient.Client(cmd_ctx.session)
     console = client.consoles.console
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        stogrps = console.storage_groups.list()
+        stogrps = console.storage_groups.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_storagevolume.py
+++ b/zhmccli/_cmd_storagevolume.py
@@ -25,7 +25,8 @@ from ._cmd_port import find_port
 from ._cmd_storagegroup import find_storagegroup
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS, EMAIL_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, EMAIL_OPTIONS
 
 
 ALL_USAGES = ['boot', 'data']
@@ -79,6 +80,7 @@ def storagevolume_group():
 @storagevolume_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('STORAGEGROUP', type=str, metavar='STORAGEGROUP')
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def storagevolume_list(cmd_ctx, storagegroup, **options):
     """
@@ -277,8 +279,9 @@ def cmd_storagevolume_list(cmd_ctx, stogrp_name, options):
     client = zhmcclient.Client(cmd_ctx.session)
     stogrp = find_storagegroup(cmd_ctx, client, stogrp_name)
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        stovols = stogrp.storage_volumes.list()
+        stovols = stogrp.storage_volumes.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_unmanaged_cpc.py
+++ b/zhmccli/_cmd_unmanaged_cpc.py
@@ -21,7 +21,8 @@ import click
 
 import zhmcclient
 from .zhmccli import cli
-from ._helper import print_resources, click_exception, COMMAND_OPTIONS_METAVAR
+from ._helper import print_resources, click_exception, \
+    COMMAND_OPTIONS_METAVAR, add_options, FILTER_OPTIONS, build_filter_args
 
 
 def find_unmanaged_cpc(cmd_ctx, console, cpc_name):
@@ -49,6 +50,7 @@ def ucpc_group():
 @ucpc_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.option('--uri', is_flag=True, required=False,
               help='Add the resource URI to the properties shown')
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def ucpc_list(cmd_ctx, **options):
     """
@@ -67,8 +69,9 @@ def cmd_ucpc_list(cmd_ctx, options):
     client = zhmcclient.Client(cmd_ctx.session)
     console = client.consoles.console
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        ucpcs = console.unmanaged_cpcs.list()
+        ucpcs = console.unmanaged_cpcs.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_user.py
+++ b/zhmccli/_cmd_user.py
@@ -24,8 +24,9 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS, ObjectByUriCache, \
-    API_VERSION_HMC_2_14_0, API_VERSION_HMC_2_15_0
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, ObjectByUriCache, API_VERSION_HMC_2_14_0, \
+    API_VERSION_HMC_2_15_0
 
 
 def find_user(cmd_ctx, console, user_name):
@@ -52,6 +53,7 @@ def user_group():
 
 @user_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.option('--permissions', is_flag=True, required=False,
               help='Show additional properties for user permissions and roles.')
 @click.option('--status', is_flag=True, required=False,
@@ -555,8 +557,10 @@ def cmd_user_list(cmd_ctx, options):
     additions['roles'] = {}
     additions['password-rule'] = {}
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        users = console.users.list(full_properties=False)
+        users = console.users.list(
+            full_properties=False, filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_user_pattern.py
+++ b/zhmccli/_cmd_user_pattern.py
@@ -23,7 +23,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS, parse_yaml_flow_style
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, parse_yaml_flow_style
 
 
 # Special default for retention-time when creating
@@ -60,6 +61,7 @@ def user_pattern_group():
 
 @user_pattern_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def user_pattern_list(cmd_ctx, **options):
     """
@@ -434,8 +436,10 @@ def cmd_user_pattern_list(cmd_ctx, options):
 
     additions = {}
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        user_patterns = console.user_patterns.list(full_properties=False)
+        user_patterns = console.user_patterns.list(
+            full_properties=False, filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_user_role.py
+++ b/zhmccli/_cmd_user_role.py
@@ -25,7 +25,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS, ObjectByUriCache
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, ObjectByUriCache
 
 
 PERMISSION_OPTIONS = [
@@ -232,6 +233,7 @@ def user_role_group():
 
 @user_role_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.option('--permissions', is_flag=True, required=False,
               help='Show additional properties for user role permissions.')
 @click.pass_obj
@@ -411,8 +413,10 @@ def cmd_user_role_list(cmd_ctx, options):
     additions = {}
     additions['permissions'] = {}
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        user_roles = console.user_roles.list(full_properties=False)
+        user_roles = console.user_roles.list(
+            full_properties=False, filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_vfunction.py
+++ b/zhmccli/_cmd_vfunction.py
@@ -23,7 +23,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args
 
 from ._cmd_partition import find_partition
 
@@ -59,6 +60,7 @@ def vfunction_group():
 @click.argument('CPC', type=str, metavar='CPC')
 @click.argument('PARTITION', type=str, metavar='PARTITION')
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def vfunction_list(cmd_ctx, cpc, partition, **options):
     """
@@ -183,8 +185,9 @@ def cmd_vfunction_list(cmd_ctx, cpc_name, partition_name, options):
     client = zhmcclient.Client(cmd_ctx.session)
     partition = find_partition(cmd_ctx, client, cpc_name, partition_name)
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        vfunctions = partition.virtual_functions.list()
+        vfunctions = partition.virtual_functions.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_vstorageresource.py
+++ b/zhmccli/_cmd_vstorageresource.py
@@ -26,7 +26,8 @@ from ._cmd_port import find_port
 from ._cmd_storagegroup import find_storagegroup
 from ._helper import print_properties, print_resources, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args
 
 
 def find_vstorageresource(cmd_ctx, client, stogrp_name, vsr_name):
@@ -65,6 +66,7 @@ def vstorageresource_group():
 @vstorageresource_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('STORAGEGROUP', type=str, metavar='STORAGEGROUP')
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.pass_obj
 def vstorageresource_list(cmd_ctx, storagegroup, **options):
     """
@@ -151,8 +153,9 @@ def cmd_vstorageresource_list(cmd_ctx, stogrp_name, options):
     stogrp = find_storagegroup(cmd_ctx, client, stogrp_name)
     cpc = stogrp.cpc
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        vsrs = stogrp.virtual_storage_resources.list()
+        vsrs = stogrp.virtual_storage_resources.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_vswitch.py
+++ b/zhmccli/_cmd_vswitch.py
@@ -23,7 +23,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
-    click_exception, add_options, LIST_OPTIONS
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args
 from ._cmd_cpc import find_cpc
 
 
@@ -61,6 +62,7 @@ def vswitch_group():
 @vswitch_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @click.argument('CPC', type=str, metavar='CPC')
 @add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
 @click.option('--adapter', is_flag=True, required=False, hidden=True)
 @click.pass_obj
 def vswitch_list(cmd_ctx, cpc, **options):
@@ -125,8 +127,9 @@ def cmd_vswitch_list(cmd_ctx, cpc_name, options):
     client = zhmcclient.Client(cmd_ctx.session)
     cpc = find_cpc(cmd_ctx, client, cpc_name)
 
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
     try:
-        vswitches = cpc.virtual_switches.list()
+        vswitches = cpc.virtual_switches.list(filter_args=filter_args)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 


### PR DESCRIPTION
For details, see the commit message.

I testes this on AHPS with the following commands:
```
# general tests
zhmc cpc list --help                                       # test help text
zhmc cpc list --filter                                     # test error handling for missing option arg
zhmc cpc list --filter xxx                                 # test error handling for missing "="

# cpc has no additional properties in list output
zhmc cpc list                                              # test no filtering
zhmc cpc list --filter name=A224                           # test string property
zhmc cpc list --filter "name='A224'"                       # test string with single quotes
zhmc cpc list --filter 'name="A224"'                       # test string with double quotes
zhmc cpc list --filter "name=A.*"                          # test regular expression matching
zhmc cpc list --filter dpm-enabled=true                    # test boolean property
zhmc cpc list --filter dpm-enabled=false                   # test boolean property
zhmc cpc list --filter "status=(active|service-required)"  # test regular expression matching
zhmc cpc list --filter dpm-enabled=true,status=active      # test multiple properties
zhmc cpc list --filter status=active                       # test property in table and in list() result
zhmc cpc list --filter "machine-type=39.*"                 # test property in table but non in list() result
zhmc cpc list --filter processor-count-ifl=200             # test int property not in table and non in list() result
zhmc cpc list --filter machine-type=3931                   # test string property with int value -> Traceback with TypeError
zhmc cpc list --filter "machine-type='3931'"               # test string property with int value in quotes

# adapter has additional properties in list output and requires CPC
zhmc adapter list AHPS                                     # test no filtering
zhmc adapter list AHPS --filter cpc=AHPS                   # test additional property (not supported, empty result)
zhmc adapter list AHPS --filter type=crypto                # test string property
zhmc adapter list AHPS --filter type=crypto,status=active  # test multiple properties

# partition has additional properties in list output and can omit CPC
zhmc partition list                                        # test no filtering
zhmc partition list --filter cpc=AHPS                      # test additional property (not supported, empty result)
zhmc partition list --filter type=linux                    # test string property 
zhmc partition list --filter ifl-processors=6              # test int property 
```