### PR TITLE
Support for sorting output of list commands by properties

### DIFF
--- a/changes/742.feature.rst
+++ b/changes/742.feature.rst
@@ -1,0 +1,3 @@
+The output of all `list` commands can now be sorted by using a new `--sort`
+option that allows specifying one or more property names. There is a default
+sorting by resource name (and parent name, if multiple parents can be listed).

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -27,7 +27,8 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, domain_config_to_props_list, print_dicts
+    build_filter_args, SORT_OPTIONS, build_sort_props, \
+    domain_config_to_props_list, print_dicts
 from ._cmd_cpc import find_cpc
 
 
@@ -92,6 +93,7 @@ def adapter_group():
 @click.option('--type', is_flag=True, required=False, hidden=True)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def adapter_list(cmd_ctx, cpc, **options):
     """
@@ -315,9 +317,10 @@ def cmd_adapter_list(cmd_ctx, cpc_name, options):
         'cpc': cpc_additions,
     }
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, adapters, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_capacitygroup.py
+++ b/zhmccli/_cmd_capacitygroup.py
@@ -24,7 +24,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args
+    build_filter_args, SORT_OPTIONS, build_sort_props
 from ._cmd_cpc import find_cpc
 from ._cmd_partition import find_partition
 
@@ -68,6 +68,7 @@ def capacitygroup_group():
 @click.argument('CPC', type=str, metavar='CPC')
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def capacitygroup_list(cmd_ctx, cpc, **options):
     """
@@ -288,9 +289,11 @@ def cmd_capacitygroup_list(cmd_ctx, cpc_name, options):
         'partitions': partitions_additions,
     }
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, capacitygroups, cmd_ctx.output_format,
-                        show_list, additions, all=options['all'])
+                        show_list, additions, all=options['all'],
+                        sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_certificates.py
+++ b/zhmccli/_cmd_certificates.py
@@ -23,7 +23,8 @@ import zhmcclient
 from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, COMMAND_OPTIONS_METAVAR, click_exception, \
-    add_options, LIST_OPTIONS, FILTER_OPTIONS, build_filter_args
+    add_options, LIST_OPTIONS, FILTER_OPTIONS, build_filter_args, \
+    SORT_OPTIONS, build_sort_props
 
 
 def find_certificate(cmd_ctx, client, cert_name):
@@ -95,6 +96,7 @@ def certificate_delete(cmd_ctx, certificate, **options):
 @certificate_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def certificate_list(cmd_ctx, **options):
     """
@@ -218,9 +220,10 @@ def cmd_certificate_list(cmd_ctx, options):
             'object-uri',
         ])
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, certificates, cmd_ctx.output_format, show_list,
-                        None, all=options['all'])
+                        None, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -29,7 +29,7 @@ from tabulate import tabulate
 from ._helper import print_properties, print_resources, print_list, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, TABLE_FORMATS, \
+    build_filter_args, SORT_OPTIONS, build_sort_props, TABLE_FORMATS, \
     hide_property, required_option, validate, print_dicts, get_level_str, \
     prompt_ftp_password, convert_ec_mcl_description, get_mcl_str, \
     parse_ec_levels, parse_timestamp, TIMESTAMP_BEGIN_DEFAULT, \
@@ -198,6 +198,7 @@ def cpc_group():
 @click.option('--mach', is_flag=True, required=False, hidden=True)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def cpc_list(cmd_ctx, **options):
     """
@@ -966,9 +967,10 @@ def cmd_cpc_list(cmd_ctx, options):
             'object-uri',
         ])
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, cpcs, cmd_ctx.output_format, show_list,
-                        all=options['all'])
+                        all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_hba.py
+++ b/zhmccli/_cmd_hba.py
@@ -24,7 +24,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args
+    build_filter_args, SORT_OPTIONS, build_sort_props
 from ._cmd_partition import find_partition
 
 
@@ -59,6 +59,7 @@ def hba_group():
 @click.argument('PARTITION', type=str, metavar='PARTITION')
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def hba_list(cmd_ctx, cpc, partition, **options):
     """
@@ -205,9 +206,10 @@ def cmd_hba_list(cmd_ctx, cpc_name, partition_name, options):
         'partition': partition_additions,
     }
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, hbas, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_imageprofile.py
+++ b/zhmccli/_cmd_imageprofile.py
@@ -25,7 +25,8 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, str2int, absolute_capping_value, parse_yaml_flow_style
+    build_filter_args, SORT_OPTIONS, build_sort_props, str2int, \
+    absolute_capping_value, parse_yaml_flow_style
 from ._cmd_cpc import find_cpc
 from ._cmd_certificates import find_certificate
 
@@ -70,6 +71,7 @@ def imageprofile_group():
 @click.argument('cpc', type=str, metavar='[CPC]', required=False)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def imageprofile_list(cmd_ctx, cpc, **options):
     """
@@ -1583,10 +1585,11 @@ def cmd_imageprofile_list(cmd_ctx, cpc_name, options):
             cpc = imageprofile.manager.parent
             additions['cpc'][imageprofile.uri] = cpc.name
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(
             cmd_ctx, imageprofiles, cmd_ctx.output_format, show_list,
-            additions, all=options['all'])
+            additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_ldap_server_definition.py
+++ b/zhmccli/_cmd_ldap_server_definition.py
@@ -24,7 +24,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args
+    build_filter_args, SORT_OPTIONS, build_sort_props
 
 
 def find_ldapdef(cmd_ctx, console, ldapdef_name):
@@ -53,6 +53,7 @@ def ldapdef_group():
 @ldapdef_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def ldapdef_list(cmd_ctx, **options):
     """
@@ -254,9 +255,11 @@ def cmd_ldapdef_list(cmd_ctx, options):
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, ldapdefs, cmd_ctx.output_format,
-                        show_list, additions, all=options['all'])
+                        show_list, additions, all=options['all'],
+                        sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_loadprofile.py
+++ b/zhmccli/_cmd_loadprofile.py
@@ -25,7 +25,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, str2int
+    build_filter_args, SORT_OPTIONS, build_sort_props, str2int
 from ._cmd_cpc import find_cpc
 
 
@@ -68,6 +68,7 @@ def loadprofile_group():
 @click.argument('cpc', type=str, metavar='[CPC]', required=False)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def loadprofile_list(cmd_ctx, cpc, **options):
     """
@@ -467,10 +468,11 @@ def cmd_loadprofile_list(cmd_ctx, cpc_name, options):
             cpc = loadprofile.manager.parent
             additions['cpc'][loadprofile.uri] = cpc.name
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(
             cmd_ctx, loadprofiles, cmd_ctx.output_format, show_list,
-            additions, all=options['all'])
+            additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_lpar.py
+++ b/zhmccli/_cmd_lpar.py
@@ -26,7 +26,8 @@ from .zhmccli import cli, CONSOLE_LOGGER_NAME
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     part_console, click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, TABLE_FORMATS, hide_property, ASYNC_TIMEOUT_OPTIONS, \
+    build_filter_args, SORT_OPTIONS, build_sort_props, TABLE_FORMATS, \
+    hide_property, ASYNC_TIMEOUT_OPTIONS, \
     API_VERSION_HMC_2_14_0, absolute_capping_value, parse_yaml_flow_style
 from ._cmd_cpc import find_cpc
 from ._cmd_certificates import find_certificate
@@ -84,6 +85,7 @@ def lpar_group():
 @click.option('--type', is_flag=True, required=False, hidden=True)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def lpar_list(cmd_ctx, cpc, **options):
     """
@@ -876,9 +878,11 @@ def cmd_lpar_list(cmd_ctx, cpc_name, options):
         cpc = lpar.manager.parent
         additions['cpc'][lpar.uri] = cpc.name
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'],
+                                  default=['cpc', 'name'])
     try:
         print_resources(cmd_ctx, lpars, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_nic.py
+++ b/zhmccli/_cmd_nic.py
@@ -24,7 +24,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args
+    build_filter_args, SORT_OPTIONS, build_sort_props
 from ._cmd_partition import find_partition
 from ._cmd_cpc import find_cpc
 
@@ -65,6 +65,7 @@ def nic_group():
 @click.option('--type', is_flag=True, required=False, hidden=True)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def nic_list(cmd_ctx, cpc, partition, **options):
     """
@@ -407,9 +408,10 @@ def cmd_nic_list(cmd_ctx, cpc_name, partition_name, options):
         'partition': partition_additions,
     }
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, nics, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_partition.py
+++ b/zhmccli/_cmd_partition.py
@@ -30,7 +30,7 @@ from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     part_console, click_exception, storage_management_feature, \
     add_options, LIST_OPTIONS, FILTER_OPTIONS, build_filter_args, \
-    TABLE_FORMATS, hide_property, \
+    SORT_OPTIONS, build_sort_props, TABLE_FORMATS, hide_property, \
     ASYNC_TIMEOUT_OPTIONS, API_VERSION_HMC_2_14_0, parse_adapter_names, \
     parse_crypto_domains, domains_to_domain_config, \
     domain_config_to_props_list, print_dicts, API_VERSION_HMC_2_16_0
@@ -107,6 +107,7 @@ def partition_group():
 @click.option('--type', is_flag=True, required=False, hidden=True)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.option('--ifl-usage', is_flag=True, required=False,
               help='Show additional properties for IFL usage.')
 @click.option('--cp-usage', is_flag=True, required=False,
@@ -1300,9 +1301,11 @@ Help for usage related options of the partition list command:
         cpc = p.manager.parent
         additions['cpc'][p.uri] = cpc.name
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'],
+                                  default=['cpc', 'name'])
     try:
         print_resources(cmd_ctx, partitions, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_password_rule.py
+++ b/zhmccli/_cmd_password_rule.py
@@ -24,7 +24,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args
+    build_filter_args, SORT_OPTIONS, build_sort_props
 
 
 def find_password_rule(cmd_ctx, console, password_rule_name):
@@ -52,6 +52,7 @@ def password_rule_group():
 @password_rule_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def password_rule_list(cmd_ctx, **options):
     """
@@ -228,9 +229,11 @@ def cmd_password_rule_list(cmd_ctx, options):
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, password_rules, cmd_ctx.output_format,
-                        show_list, additions, all=options['all'])
+                        show_list, additions, all=options['all'],
+                        sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_port.py
+++ b/zhmccli/_cmd_port.py
@@ -24,7 +24,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args
+    build_filter_args, SORT_OPTIONS, build_sort_props
 from ._cmd_adapter import find_adapter
 
 
@@ -65,6 +65,7 @@ def port_group():
 @click.argument('ADAPTER', type=str, metavar='ADAPTER')
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def port_list(cmd_ctx, cpc, adapter, **options):
     """
@@ -161,9 +162,10 @@ def cmd_port_list(cmd_ctx, cpc_name, adapter_name, options):
         'cpc': cpc_additions,
     }
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, ports, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_resetprofile.py
+++ b/zhmccli/_cmd_resetprofile.py
@@ -25,7 +25,8 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, str2int, parse_yaml_flow_style
+    build_filter_args, SORT_OPTIONS, build_sort_props, str2int, \
+    parse_yaml_flow_style
 from ._cmd_cpc import find_cpc
 
 
@@ -69,6 +70,7 @@ def resetprofile_group():
 @click.argument('cpc', type=str, metavar='[CPC]', required=False)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def resetprofile_list(cmd_ctx, cpc, **options):
     """
@@ -300,10 +302,11 @@ def cmd_resetprofile_list(cmd_ctx, cpc_name, options):
             cpc = resetprofile.manager.parent
             additions['cpc'][resetprofile.uri] = cpc.name
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(
             cmd_ctx, resetprofiles, cmd_ctx.output_format, show_list,
-            additions, all=options['all'])
+            additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_storagegroup.py
+++ b/zhmccli/_cmd_storagegroup.py
@@ -26,7 +26,8 @@ from ._cmd_port import find_port
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, EMAIL_OPTIONS, ASYNC_TIMEOUT_OPTIONS
+    build_filter_args, SORT_OPTIONS, build_sort_props, EMAIL_OPTIONS, \
+    ASYNC_TIMEOUT_OPTIONS
 
 
 ALL_TYPES = ['fcp', 'fc']
@@ -83,6 +84,7 @@ def storagegroup_group():
 @storagegroup_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def storagegroup_list(cmd_ctx, **options):
     """
@@ -400,9 +402,10 @@ def cmd_storagegroup_list(cmd_ctx, options):
         'cpc': cpc_additions,
     }
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, stogrps, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_storagevolume.py
+++ b/zhmccli/_cmd_storagevolume.py
@@ -26,7 +26,7 @@ from ._cmd_storagegroup import find_storagegroup
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, EMAIL_OPTIONS
+    build_filter_args, SORT_OPTIONS, build_sort_props, EMAIL_OPTIONS
 
 
 ALL_USAGES = ['boot', 'data']
@@ -81,6 +81,7 @@ def storagevolume_group():
 @click.argument('STORAGEGROUP', type=str, metavar='STORAGEGROUP')
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def storagevolume_list(cmd_ctx, storagegroup, **options):
     """
@@ -309,9 +310,10 @@ def cmd_storagevolume_list(cmd_ctx, stogrp_name, options):
         'storagegroup': sg_additions,
     }
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, stovols, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_unmanaged_cpc.py
+++ b/zhmccli/_cmd_unmanaged_cpc.py
@@ -22,7 +22,8 @@ import click
 import zhmcclient
 from .zhmccli import cli
 from ._helper import print_resources, click_exception, \
-    COMMAND_OPTIONS_METAVAR, add_options, FILTER_OPTIONS, build_filter_args
+    COMMAND_OPTIONS_METAVAR, add_options, FILTER_OPTIONS, build_filter_args, \
+    SORT_OPTIONS, build_sort_props
 
 
 def find_unmanaged_cpc(cmd_ctx, console, cpc_name):
@@ -51,6 +52,7 @@ def ucpc_group():
 @click.option('--uri', is_flag=True, required=False,
               help='Add the resource URI to the properties shown')
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def ucpc_list(cmd_ctx, **options):
     """
@@ -83,8 +85,9 @@ def cmd_ucpc_list(cmd_ctx, options):
             'object-uri',
         ])
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, ucpcs, cmd_ctx.output_format, show_list,
-                        all=False)
+                        all=False, sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)

--- a/zhmccli/_cmd_user.py
+++ b/zhmccli/_cmd_user.py
@@ -25,8 +25,8 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, ObjectByUriCache, API_VERSION_HMC_2_14_0, \
-    API_VERSION_HMC_2_15_0
+    build_filter_args, SORT_OPTIONS, build_sort_props, ObjectByUriCache, \
+    API_VERSION_HMC_2_14_0, API_VERSION_HMC_2_15_0
 
 
 def find_user(cmd_ctx, console, user_name):
@@ -54,6 +54,7 @@ def user_group():
 @user_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.option('--permissions', is_flag=True, required=False,
               help='Show additional properties for user permissions and roles.')
 @click.option('--status', is_flag=True, required=False,
@@ -585,9 +586,10 @@ def cmd_user_list(cmd_ctx, options):
             else:
                 additions['password-rule'][user.uri] = None
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, users, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_user_pattern.py
+++ b/zhmccli/_cmd_user_pattern.py
@@ -24,7 +24,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, parse_yaml_flow_style
+    build_filter_args, SORT_OPTIONS, build_sort_props, parse_yaml_flow_style
 
 
 # Special default for retention-time when creating
@@ -62,6 +62,7 @@ def user_pattern_group():
 @user_pattern_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def user_pattern_list(cmd_ctx, **options):
     """
@@ -443,9 +444,11 @@ def cmd_user_pattern_list(cmd_ctx, options):
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, user_patterns, cmd_ctx.output_format,
-                        show_list, additions, all=options['all'])
+                        show_list, additions, all=options['all'],
+                        sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_user_role.py
+++ b/zhmccli/_cmd_user_role.py
@@ -26,7 +26,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args, ObjectByUriCache
+    build_filter_args, SORT_OPTIONS, build_sort_props, ObjectByUriCache
 
 
 PERMISSION_OPTIONS = [
@@ -234,6 +234,7 @@ def user_role_group():
 @user_role_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.option('--permissions', is_flag=True, required=False,
               help='Show additional properties for user role permissions.')
 @click.pass_obj
@@ -428,9 +429,10 @@ def cmd_user_role_list(cmd_ctx, options):
                 permissions.append(permission_str(obj_cache, item))
             additions['permissions'][role.uri] = permissions
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, user_roles, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_vfunction.py
+++ b/zhmccli/_cmd_vfunction.py
@@ -24,7 +24,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args
+    build_filter_args, SORT_OPTIONS, build_sort_props
 
 from ._cmd_partition import find_partition
 
@@ -61,6 +61,7 @@ def vfunction_group():
 @click.argument('PARTITION', type=str, metavar='PARTITION')
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def vfunction_list(cmd_ctx, cpc, partition, **options):
     """
@@ -215,9 +216,10 @@ def cmd_vfunction_list(cmd_ctx, cpc_name, partition_name, options):
         'partition': partition_additions,
     }
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, vfunctions, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_vstorageresource.py
+++ b/zhmccli/_cmd_vstorageresource.py
@@ -27,7 +27,7 @@ from ._cmd_storagegroup import find_storagegroup
 from ._helper import print_properties, print_resources, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args
+    build_filter_args, SORT_OPTIONS, build_sort_props
 
 
 def find_vstorageresource(cmd_ctx, client, stogrp_name, vsr_name):
@@ -67,6 +67,7 @@ def vstorageresource_group():
 @click.argument('STORAGEGROUP', type=str, metavar='STORAGEGROUP')
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.pass_obj
 def vstorageresource_list(cmd_ctx, storagegroup, **options):
     """
@@ -218,9 +219,10 @@ def cmd_vstorageresource_list(cmd_ctx, stogrp_name, options):
         'wwpn-status': wwpn_status_additions,
     }
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, vsrs, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_vswitch.py
+++ b/zhmccli/_cmd_vswitch.py
@@ -24,7 +24,7 @@ from .zhmccli import cli
 from ._helper import print_properties, print_resources, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
-    build_filter_args
+    build_filter_args, SORT_OPTIONS, build_sort_props
 from ._cmd_cpc import find_cpc
 
 
@@ -63,6 +63,7 @@ def vswitch_group():
 @click.argument('CPC', type=str, metavar='CPC')
 @add_options(LIST_OPTIONS)
 @add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
 @click.option('--adapter', is_flag=True, required=False, hidden=True)
 @click.pass_obj
 def vswitch_list(cmd_ctx, cpc, **options):
@@ -168,9 +169,10 @@ def cmd_vswitch_list(cmd_ctx, cpc_name, options):
         'adapter': adapter_additions,
     }
 
+    sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, vswitches, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'])
+                        additions, all=options['all'], sort_props=sort_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 


### PR DESCRIPTION
For details, see the commit message.

I tested this on AHPS with the following commands:
```
# general tests
zhmc cpc list --help                                  # test help text
zhmc cpc list --sort                                  # test error handling for missing option arg
zhmc cpc list --sort xxx                              # test error handling for invalid property name

# cpc has no additional properties in list output
zhmc cpc list                                         # test default sorting (name)
zhmc cpc list --sort name                             # test excplicit default sort
zhmc cpc list --sort dpm-enabled                      # test boolean property
zhmc cpc list --sort dpm-enabled,name                 # test boolean + string property
zhmc cpc list --sort status                           # test property in table and in list() result
zhmc cpc list --sort machine-type                     # test property in table but non in list() result
zhmc cpc list --sort processor-count-ifl              # test property not in table and non in list() result

# adapter has additional properties in list output and requires CPC
zhmc adapter list AHPS                                # test default sorting (name)
zhmc adapter list AHPS --sort name                    # test excplicit default sort
zhmc adapter list AHPS --sort cpc,name                # test with additional property as first
zhmc adapter list AHPS --sort adapter-id              # test string property

# partition has additional properties in list output and can omit CPC
zhmc partition list                                   # test default sorting (cpc,name)
zhmc partition list --sort cpc,name                   # test excplicit default sort
zhmc partition list --sort name                       # test sort by name across CPCs
zhmc partition list --sort name,cpc                   # test with additional property as last
zhmc partition list AHPS --sort ifl-processors        # test integer property
zhmc partition list AHPS --sort ifl-processors,name   # test integer + string property
zhmc partition list AHPS --sort os-name               # test null values
```