### PR TITLE
Fixed null values for list --all; Made CSV quoting consistent

### DIFF
--- a/changes/731.fix.rst
+++ b/changes/731.fix.rst
@@ -1,0 +1,2 @@
+Fixed the bug that properties added with the `--all` option had null values
+in certain cases for the csv and json output formats.

--- a/changes/731.incompatible.rst
+++ b/changes/731.incompatible.rst
@@ -1,0 +1,7 @@
+Made the CSV quoting consistent for all Python versions. Previously, on
+Python 3.12 and higher, complex types were only quoted when needed and
+None became an unquoted empty string, and on Python 3.11 and lower, complex
+types are always quoted and None becomes a quoted empty string. Now, complex
+types are always quoted and None becomes a quoted empty string, on all Python
+versions. Depending on how the generated CSV output is processed, this may
+be an incompatible change on Python 3.12 and higher.

--- a/tests/end2end/test_cpc.py
+++ b/tests/end2end/test_cpc.py
@@ -16,40 +16,290 @@
 End2end tests for the 'zhmc cpc' command group.
 """
 
-
+import io
 import json
+import csv
 import urllib3
+import pytest
 import zhmcclient
-# pylint: disable=line-too-long,unused-import
-from zhmcclient.testutils import hmc_definition  # noqa: F401, E501
-from .utils import zhmc_session  # noqa: F401, E501
-# pylint: enable=line-too-long,unused-import
+# pylint: disable=unused-import
+from zhmcclient.testutils import hmc_definition  # noqa: F401
+# pylint: enable=unused-import
+from zhmccli._helper import CSV_DELIM, CSV_QUOTE
+# pylint: disable=unused-import
+from .utils import zhmc_session  # noqa: F401
+# pylint: enable=unused-import
 
 from .utils import run_zhmc, pick_test_resources
 
 urllib3.disable_warnings()
 
 
-def test_cpc_list(zhmc_session):  # noqa: F811
+# Expected output properties when --names-only option is specified
+CPC_PROPS_NAMES_ONLY = [
+    "name",
+]
+
+# Expected output properties when no other options are specified
+CPC_PROPS_DEFAULT = CPC_PROPS_NAMES_ONLY + [
+    "description",
+    "dpm-enabled",
+    "machine-model",
+    "machine-serial-number",
+    "machine-type",
+    "se-version",
+    "status",
+]
+
+# Expected output properties when --uri option is specified
+CPC_PROPS_URI = CPC_PROPS_DEFAULT + [
+    "object-uri",
+]
+
+# Expected output properties when --all option is specified
+# Note: These are the z15 properties. Additional properties are allowed.
+CPC_PROPS_ALL = [
+    "acceptable-status",
+    "additional-status",
+    "auto-start-list",
+    "available-features-list",
+    "cbu-activation-date",
+    "cbu-expiration-date",
+    "cbu-number-of-tests-left",
+    "class",
+    "cpc-node-descriptor",
+    "cpc-power-cap-allowed",
+    "cpc-power-cap-current",
+    "cpc-power-cap-maximum",
+    "cpc-power-cap-minimum",
+    "cpc-power-capping-state",
+    "cpc-power-consumption",
+    "cpc-power-rating",
+    "cpc-power-save-allowed",
+    "cpc-power-saving",
+    "cpc-power-saving-state",
+    "cpc-serial-number",
+    "degraded-status",
+    "description",
+    "dpm-enabled",
+    "ec-mcl-description",
+    "global-primary-key-hash",
+    "global-secondary-key-hash",
+    "has-automatic-se-switch-enabled",
+    "has-hardware-messages",
+    "has-temporary-capacity-change-allowed",
+    "has-unacceptable-status",
+    "host-primary-key-hash",
+    "host-secondary-key-hash",
+    "iml-mode",
+    "is-cbu-activated",
+    "is-cbu-enabled",
+    "is-cbu-installed",
+    "is-cpacf-enabled",
+    "is-global-key-installed",
+    "is-host-key-installed",
+    "is-locked",
+    "is-on-off-cod-activated",
+    "is-on-off-cod-enabled",
+    "is-on-off-cod-installed",
+    "is-real-cbu-available",
+    "is-secure-execution-enabled",
+    "is-service-required",
+    "lan-interface1-address",
+    "lan-interface1-type",
+    "lan-interface2-address",
+    "lan-interface2-type",
+    "last-energy-advice-time",
+    "machine-model",
+    "machine-serial-number",
+    "machine-type",
+    "management-world-wide-port-name",
+    "maximum-alternate-storage-sites",
+    "maximum-fid-number",
+    "maximum-hipersockets",
+    "maximum-ism-vchids",
+    "maximum-partitions",
+    "minimum-fid-number",
+    "msu-permanent",
+    "msu-permanent-plus-billable",
+    "msu-permanent-plus-temporary",
+    "name",
+    "network1-ipv4-alt-ipaddr",
+    "network1-ipv4-mask",
+    "network1-ipv4-pri-ipaddr",
+    "network1-ipv6-info",
+    "network2-ipv4-alt-ipaddr",
+    "network2-ipv4-mask",
+    "network2-ipv4-pri-ipaddr",
+    "network2-ipv6-info",
+    "object-id",
+    "object-uri",
+    "on-off-cod-activation-date",
+    "parent",
+    "processor-count-aap",
+    "processor-count-defective",
+    "processor-count-general-purpose",
+    "processor-count-icf",
+    "processor-count-ifl",
+    "processor-count-iip",
+    "processor-count-pending",
+    "processor-count-pending-aap",
+    "processor-count-pending-general-purpose",
+    "processor-count-pending-icf",
+    "processor-count-pending-ifl",
+    "processor-count-pending-iip",
+    "processor-count-pending-service-assist",
+    "processor-count-service-assist",
+    "processor-count-spare",
+    "se-version",
+    "sna-name",
+    "software-model-permanent",
+    "software-model-permanent-plus-billable",
+    "software-model-permanent-plus-temporary",
+    "status",
+    "storage-customer",
+    "storage-customer-available",
+    "storage-customer-central",
+    "storage-customer-expanded",
+    "storage-hardware-system-area",
+    "storage-total-installed",
+    "storage-vfm-increment-size",
+    "storage-vfm-total",
+    "zcpc-ambient-temperature",
+    "zcpc-dew-point",
+    "zcpc-environmental-class",
+    "zcpc-exhaust-temperature",
+    "zcpc-heat-load",
+    "zcpc-heat-load-forced-air",
+    "zcpc-heat-load-water",
+    "zcpc-humidity",
+    "zcpc-maximum-inlet-air-temperature",
+    "zcpc-maximum-inlet-liquid-temperature",
+    "zcpc-maximum-potential-heat-load",
+    "zcpc-maximum-potential-power",
+    "zcpc-minimum-inlet-air-temperature",
+    "zcpc-power-cap-allowed",
+    "zcpc-power-cap-current",
+    "zcpc-power-cap-maximum",
+    "zcpc-power-cap-minimum",
+    "zcpc-power-capping-state",
+    "zcpc-power-consumption",
+    "zcpc-power-rating",
+    "zcpc-power-save-allowed",
+    "zcpc-power-saving",
+    "zcpc-power-saving-state",
+]
+
+# Volatile properties (whose values are not verified)
+CPC_PROPS_VOLATILE = [
+    "cpc-power-consumption",
+    "zcpc-ambient-temperature",
+    "zcpc-dew-point",
+    "zcpc-exhaust-temperature",
+    "zcpc-heat-load",
+    "zcpc-heat-load-forced-air",
+    "zcpc-heat-load-water",
+    "zcpc-humidity",
+    "zcpc-maximum-inlet-air-temperature",
+    "zcpc-maximum-inlet-liquid-temperature",
+    "zcpc-maximum-potential-heat-load",
+    "zcpc-maximum-potential-power",
+    "zcpc-minimum-inlet-air-temperature",
+    "zcpc-power-consumption",
+]
+
+
+TESTCASES_CPC_LIST = [
+    # Testcases for test_cpc_list()
+    # Each list item is a testcase, which is a tuple with items:
+    # - options (list of str): Options for 'zhmc cpc list' command
+    # - exp_props (list of str): Expected property names in output
+    # - exact (bool): If True, the output property names must be exactly the
+    #   expected properties. If False, additional properties are allowed.
+    (
+        ['--names-only'],
+        CPC_PROPS_NAMES_ONLY,
+        True,
+    ),
+    (
+        [],
+        CPC_PROPS_DEFAULT,
+        True,
+    ),
+    (
+        ['--uri'],
+        CPC_PROPS_URI,
+        True,
+    ),
+    (
+        ['--all'],
+        CPC_PROPS_ALL,
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "options, exp_props, exact",
+    TESTCASES_CPC_LIST
+)
+@pytest.mark.parametrize(
+    "out_format",
+    ['json', 'csv']
+)
+def test_cpc_list(
+        zhmc_session, out_format, options, exp_props, exact):  # noqa: F811
     # pylint: disable=redefined-outer-name
     """
-    Test 'cpc list' command in the most simple way.
+    Test 'cpc list' command for output formats json and csv.
     """
     client = zhmcclient.Client(zhmc_session)
     cpcs = client.cpcs.list()
 
-    rc, stdout, stderr = run_zhmc(
-        ['-o', 'json', 'cpc', 'list', '--names-only'])
+    args = ['-o', out_format, 'cpc', 'list'] + options
+    rc, stdout, stderr = run_zhmc(args)
 
     assert rc == 0
     assert stderr == ""
-    out_list = json.loads(stdout)
-    assert isinstance(out_list, list)
+    if out_format == 'json':
+        out_list = json.loads(stdout)
+        assert isinstance(out_list, list)
+    else:
+        assert out_format == 'csv'
+        # Note that reading with csv.QUOTE_NONNUMERIC does not work, because it
+        # attempts to convert unquoted boolean values to float. Any other
+        # quoting value returns any unquoted values (strings, booleans,
+        # numerics) as string types.
+        out_list = list(csv.DictReader(
+            io.StringIO(stdout),
+            delimiter=CSV_DELIM, quotechar=CSV_QUOTE,
+            quoting=csv.QUOTE_MINIMAL))
     assert len(out_list) == len(cpcs)
-    cpc_names = [cpc.name for cpc in cpcs]
+    exp_cpc_dict = {cpc.name: cpc for cpc in cpcs}
     for out_item in out_list:
         assert 'name' in out_item
-        assert out_item['name'] in cpc_names
+        cpc_name = out_item['name']
+        assert cpc_name in exp_cpc_dict
+        exp_cpc = exp_cpc_dict[cpc_name]
+        for pname in exp_props:
+            assert pname in out_item
+            if pname not in CPC_PROPS_VOLATILE:
+                exp_value = exp_cpc.prop(pname, 'undefined')
+                if out_format == 'csv':
+                    # The following is consistent with reading with
+                    # quoting=csv.QUOTE_MINIMAL:
+                    if exp_value is None:
+                        exp_value = ''
+                    elif isinstance(exp_value, (bool, int, float, list, dict)):
+                        exp_value = str(exp_value)
+                assert out_item[pname] == exp_value, (
+                    f"Unexpected value for property {pname} of "
+                    f"CPC {cpc_name}:\n"
+                    f"Expected: {exp_value!r}\n"
+                    f"Actual: {out_item[pname]!r}"
+                )
+        if exact:
+            assert len(out_item) == len(exp_props)
 
 
 def test_cpc_show(zhmc_session):  # noqa: F811

--- a/tests/function/test_options.py
+++ b/tests/function/test_options.py
@@ -20,7 +20,6 @@ import os
 import subprocess
 import re
 import json
-import csv
 import pytest
 from zhmcclient import Client
 from zhmcclient_mock import FakedSession
@@ -29,11 +28,6 @@ from zhmccli._helper import convert_ec_mcl_description
 
 from .utils import call_zhmc_child, call_zhmc_inline, assert_rc, \
     assert_patterns
-
-try:
-    HAS_QUOTE_STRINGS = bool(csv.QUOTE_STRINGS)  # Added in Python 3.12
-except AttributeError:
-    HAS_QUOTE_STRINGS = False
 
 TEST_LOGFILE = 'tmp_testfile.log'
 
@@ -832,12 +826,13 @@ def test_option_format_json_dict(
 
 
 CSV_RES_STDOUT_TEMPLATE = (
+    # Note: The quoting must be consistent with how the CSV file is written.
     '"name","status","dpm-enabled","se-version","machine-type",'
     '"machine-model","machine-serial-number","description"\n'
-    '"{c1[name]}","{c1[status]}",{q}{c1[dpm-enabled]}{q},"{c1[se-version]}",'
+    '"{c1[name]}","{c1[status]}",{c1[dpm-enabled]},"{c1[se-version]}",'
     '"{c1[machine-type]}","{c1[machine-model]}","{c1[machine-serial-number]}",'
     '"{c1[description]}"\n'
-    '"{c2[name]}","{c2[status]}",{q}{c2[dpm-enabled]}{q},"{c2[se-version]}",'
+    '"{c2[name]}","{c2[status]}",{c2[dpm-enabled]},"{c2[se-version]}",'
     '"{c2[machine-type]}","{c2[machine-model]}","{c2[machine-serial-number]}",'
     '"{c2[description]}"\n'
 )
@@ -885,9 +880,8 @@ def test_option_format_csv_res(
     assert_rc(exp_rc, rc, stdout, stderr)
 
     if exp_stdout_template:
-        q = '' if HAS_QUOTE_STRINGS else '"'
         exp_stdout = exp_stdout_template.format(
-            c1=cpc1.properties, c2=cpc2.properties, q=q)
+            c1=cpc1.properties, c2=cpc2.properties, q='"')
         assert stdout == exp_stdout, (
             "Unexpected stdout:\n"
             f"Actual: {stdout!r}\n"
@@ -964,8 +958,7 @@ def test_option_format_csv_dict(
     assert_rc(exp_rc, rc, stdout, stderr)
 
     if exp_stdout_template:
-        q = '' if HAS_QUOTE_STRINGS else '"'
-        exp_stdout = exp_stdout_template.format(f1=f1, f2=f2, q=q)
+        exp_stdout = exp_stdout_template.format(f1=f1, f2=f2, q='"')
         assert stdout == exp_stdout, (
             "Unexpected stdout:\n"
             f"Actual: {stdout!r}\n"

--- a/tests/unit/test_csv.py
+++ b/tests/unit/test_csv.py
@@ -24,14 +24,8 @@ import csv
 import tempfile
 import pytest
 
+from zhmccli._helper import CSV_DELIM, CSV_QUOTE, CSV_QUOTING
 
-# CSV output
-try:
-    CSV_QUOTING = csv.QUOTE_STRINGS  # Added in Python 3.12
-except AttributeError:
-    CSV_QUOTING = csv.QUOTE_ALL
-CSV_DELIM = ","
-CSV_QUOTE = '"'
 
 PROP_NAMES = ['p1', 'p2']
 PROPS_LIST = [


### PR DESCRIPTION
For details, see the commit message.

This PR also fixes issue #761 because the extended end2end test function `test_cpc_list()` otherwise would need to add rather complex logic to cover all data types and Python versions.

I ran the extended end2end test function `test_cpc_list()` on the HMC of T224:
* All testcases for this test function pass.
* I verified that the new testcases with '--all' surface the prior bug, when using the unfixed code.