### PR TITLE
Fixed CeasedExistence in 'partition list-storagegroups'; Consolidated prop processing

### DIFF
--- a/changes/706.cleanup.rst
+++ b/changes/706.cleanup.rst
@@ -1,0 +1,7 @@
+Consolidated resource property processing between table output and json/csv
+output formats. They now use a common function to determine the resource
+properties. This changes the order of properties for the csv and json output
+formats. The properties are now consistently sorted as follows:
+The properties shown in the default output are in a specific order. Additional
+properties shown by specifying `--all` are placed after the default properties
+and are sorted by name.

--- a/changes/706.fix.1.rst
+++ b/changes/706.fix.1.rst
@@ -1,0 +1,3 @@
+Fixed the CeasedExistence error for the 'zhmc partition list-storagegroups'
+command when the logged-on user had no object access permission to a storage
+group attached to the partition.

--- a/changes/706.fix.2.rst
+++ b/changes/706.fix.2.rst
@@ -1,0 +1,2 @@
+Removed the incorrect 'device-number' property from the output of the
+'zhmc storagegroup list' command.

--- a/zhmccli/_cmd_character_rule.py
+++ b/zhmccli/_cmd_character_rule.py
@@ -209,7 +209,7 @@ def cmd_character_rule_list(cmd_ctx, password_rule_name):
 
     try:
         print_dicts(cmd_ctx, character_rules, cmd_ctx.output_format,
-                    show_list, additions, all=False)
+                    show_list, additions)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_console.py
+++ b/zhmccli/_cmd_console.py
@@ -505,7 +505,7 @@ def cmd_get_audit_log(cmd_ctx, options):
 
     cmd_ctx.spinner.stop()
     print_dicts(cmd_ctx, log_items, cmd_ctx.output_format,
-                show_list=show_list, additions=additions, all=False)
+                show_list=show_list, additions=additions)
 
 
 def cmd_get_security_log(cmd_ctx, options):
@@ -545,7 +545,7 @@ def cmd_get_security_log(cmd_ctx, options):
 
     cmd_ctx.spinner.stop()
     print_dicts(cmd_ctx, log_items, cmd_ctx.output_format,
-                show_list=show_list, additions=additions, all=False)
+                show_list=show_list, additions=additions)
 
 
 def cmd_list_api_features(cmd_ctx, options):

--- a/zhmccli/_cmd_session.py
+++ b/zhmccli/_cmd_session.py
@@ -296,4 +296,4 @@ def cmd_session_list(cmd_ctx):
     ]
 
     print_dicts(cmd_ctx, _session_list, cmd_ctx.output_format,
-                show_list=show_list, all=True)
+                show_list=show_list)

--- a/zhmccli/_cmd_storagegroup.py
+++ b/zhmccli/_cmd_storagegroup.py
@@ -378,7 +378,6 @@ def cmd_storagegroup_list(cmd_ctx, options):
     ]
     if not options['names_only']:
         show_list.extend([
-            'device-number',
             'type',
             'shared',
             'fulfillment-state',


### PR DESCRIPTION
For details, see the commit message.

I tested this with the HMC of A224:
* full end2end test: `TESTHMC=A224 make end2end`
* manually with all `zhmc ... list*` commands with output formats table, csv, json:
```
    zhmc -o $format session list
    zhmc -o $format console list-api-features
    zhmc -o $format console list-firmware
    zhmc -o $format console hw-message list
    zhmc -o $format cpc list
    zhmc -o $format cpc list-api-features $cpc
    zhmc -o $format cpc list-firmware $cpc
    zhmc -o $format cpc hw-message list $cpc
    zhmc -o $format adapter list $cpc
    zhmc -o $format adapter list-nics $cpc $adapter
    zhmc -o $format port list $cpc $adapter
    zhmc -o $format vswitch list $cpc
    zhmc -o $format capacitygroup list $cpc
    zhmc -o $format partition list $cpc
    zhmc -o $format partition list-storagegroups $cpc $partition       # the case where the error happened
    zhmc -o $format hba list $cpc $partition
    zhmc -o $format nic list $cpc $partition
    zhmc -o $format vfunction list $cpc $partition
    zhmc -o $format storagegroup list
    zhmc -o $format storagegroup list-partitions $stogrp
    zhmc -o $format storagegroup list-ports $stogrp
    zhmc -o $format storagevolume list $stogrp
    zhmc -o $format vstorageresource list $stogrp
    zhmc -o $format unmanaged_cpc list
    zhmc -o $format ldap list
    zhmc -o $format user list
    zhmc -o $format userpattern list
    zhmc -o $format userrole list
    zhmc -o $format passwordrule list
    zhmc -o $format passwordrule characterrule list Standard
    zhmc -o $format certificate list
```