### PR TITLE
1.12: Fixed CeasedExistence in 'partition list-storagegroups'; Consolidated prop processing

### DIFF
--- a/changes/706.cleanup.rst
+++ b/changes/706.cleanup.rst
@@ -1,0 +1,7 @@
+Consolidated resource property processing between table output and json
+output formats. They now use a common function to determine the resource
+properties. This changes the order of properties for the json output
+format. The properties are now consistently sorted as follows:
+The properties shown in the default output are in a specific order. Additional
+properties shown by specifying `--all` are placed after the default properties
+and are sorted by name.

--- a/changes/706.fix.1.rst
+++ b/changes/706.fix.1.rst
@@ -1,0 +1,3 @@
+Fixed the CeasedExistence error for the 'zhmc partition list-storagegroups'
+command when the logged-on user had no object access permission to a storage
+group attached to the partition.

--- a/changes/706.fix.2.rst
+++ b/changes/706.fix.2.rst
@@ -1,0 +1,2 @@
+Removed the incorrect 'device-number' property from the output of the
+'zhmc storagegroup list' command.

--- a/zhmccli/_cmd_character_rule.py
+++ b/zhmccli/_cmd_character_rule.py
@@ -209,7 +209,7 @@ def cmd_character_rule_list(cmd_ctx, password_rule_name):
 
     try:
         print_dicts(cmd_ctx, character_rules, cmd_ctx.output_format,
-                    show_list, additions, all=False)
+                    show_list, additions)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_console.py
+++ b/zhmccli/_cmd_console.py
@@ -344,7 +344,7 @@ def cmd_get_audit_log(cmd_ctx, options):
 
     cmd_ctx.spinner.stop()
     print_dicts(cmd_ctx, log_items, cmd_ctx.output_format,
-                show_list=show_list, additions=additions, all=False)
+                show_list=show_list, additions=additions)
 
 
 def cmd_get_security_log(cmd_ctx, options):
@@ -384,7 +384,7 @@ def cmd_get_security_log(cmd_ctx, options):
 
     cmd_ctx.spinner.stop()
     print_dicts(cmd_ctx, log_items, cmd_ctx.output_format,
-                show_list=show_list, additions=additions, all=False)
+                show_list=show_list, additions=additions)
 
 
 def cmd_list_api_features(cmd_ctx, options):

--- a/zhmccli/_cmd_storagegroup.py
+++ b/zhmccli/_cmd_storagegroup.py
@@ -374,7 +374,6 @@ def cmd_storagegroup_list(cmd_ctx, options):
     ]
     if not options['names_only']:
         show_list.extend([
-            'device-number',
             'type',
             'shared',
             'fulfillment-state',


### PR DESCRIPTION
Rolls back PR #763 into 1.12.

Tested against the HMC of A224:
* full end2end test: `TESTHMC=A224 make end2end`
* manually with all `zhmc ... list*` commands with output formats table, csv, json: