### PR TITLE
Consolidated and fixed zhmc output parsing for end2end; Reverted CSV quoting

### DIFF
--- a/changes/731.incompatible.rst
+++ b/changes/731.incompatible.rst
@@ -1,7 +1,0 @@
-Made the CSV quoting consistent for all Python versions. Previously, on
-Python 3.12 and higher, complex types were only quoted when needed and
-None became an unquoted empty string, and on Python 3.11 and lower, complex
-types are always quoted and None becomes a quoted empty string. Now, complex
-types are always quoted and None becomes a quoted empty string, on all Python
-versions. Depending on how the generated CSV output is processed, this may
-be an incompatible change on Python 3.12 and higher.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -593,6 +593,72 @@ output formats are supported:
        {"name": "P0ZGMR12", "status": "no-power"},
        {"name": "P0000P27", "status": "operating"}]
 
+* ``-o csv``: CSV spreadsheet format:
+
+  The generated CSV output has a header line with the names of the fields and
+  uses double quote (``"``) as the quote character and comma (``,``) as the
+  field delimiter character.
+
+  Which values are quoted in the CSV output depends on the Python version that
+  is used.
+
+  * On Python 3.13 and later:
+
+    - ``None`` will not be quoted in the CSV output and thus appears as an
+      unquoted empty string.
+    - ``int``, ``float`` and ``bool`` typed values will be unquoted in the
+      CSV output.
+    - ``str`` typed values will be quoted in the CSV output.
+    - Values with complex types (e.g. ``list``, ``dict``) will be represented
+      as their Python string representation in the CSV output and will be
+      quoted only when needed (e.g. when the string representation contains
+      a quote character or a delimiter character).
+
+  * On Python 3.12 and earlier:
+
+    - ``None`` will be quoted in the CSV output and thus appears as a quoted
+      empty string (``""``). That is not optimal since it cannot be
+      distinguished from an empty string.
+    - ``int``, ``float`` and ``bool`` typed values will remain unquoted in the
+      CSV output.
+    - ``str`` typed values will be quoted in the CSV output.
+    - Values with complex types (e.g. ``list``, ``dict``) will be represented
+      as their Python string representation in the CSV output and will always
+      be quoted.
+
+  Here is an example that uses values of different types to show the different
+  quoting:
+
+  * Given the following Python object:
+
+    .. code-block:: python
+
+        [
+            {
+                "str": "foo",
+                "int": 42,
+                "float": 3.14,
+                "bool": True,
+                "none": None,
+                "list": ["a", "b"],
+                "dict": {"a": 1},
+            }
+        ]
+
+  * The CSV output on Python 3.13 and later for this Python object would be:
+
+    .. code-block:: text
+
+        "str","int","float","bool","none","list","dict"
+        "foo",42,3.14,True,,"['a', 'b']",{'a': 1}
+
+  * The CSV output on Python 3.12 and earlier for this Python object would be:
+
+    .. code-block:: text
+
+        "str","int","float","bool","none","list","dict"
+        "foo",42,3.14,True,"","['a', 'b']","{'a': 1}"
+
 .. _`reStructuredText`: http://docutils.sourceforge.net/docs/user/rst/quickref.html#tables
 .. _`Mediawiki`: http://www.mediawiki.org/wiki/Help:Tables
 .. _`HTML`: https://www.w3.org/TR/html401/struct/tables.html

--- a/tests/end2end/test_cpc_hwmessage.py
+++ b/tests/end2end/test_cpc_hwmessage.py
@@ -125,7 +125,11 @@ def test_cpc_hwmsg_list(
                     exp_props, messages)
 
 
-def test_cpc_hwmsg_show(zhmc_session):  # noqa: F811
+@pytest.mark.parametrize(
+    "out_format",
+    ['json', 'csv']
+)
+def test_cpc_hwmsg_show(zhmc_session, out_format):  # noqa: F811
     # pylint: disable=redefined-outer-name
     """
     Test 'cpc hw-message show' command.
@@ -138,9 +142,10 @@ def test_cpc_hwmsg_show(zhmc_session):  # noqa: F811
     test_message_id = test_message.prop('element-id')
 
     rc, stdout, stderr = run_zhmc(
-        ['-o', 'json', 'cpc', 'hw-message', 'show', cpc.name, test_message_id])
+        ['-o', out_format, 'cpc', 'hw-message', 'show', cpc.name,
+         test_message_id])
 
-    assert_messages(rc, stdout, stderr, 'json', 'show', 0, "",
+    assert_messages(rc, stdout, stderr, out_format, 'show', 0, "",
                     CPC_HWMSG_PROPS_DEFAULT, [test_message])
 
 


### PR DESCRIPTION
For details, see the commit message.

I tested this on the HMC of AHPS with the complete set of end2end testcases, on Python 3.8, 3.12, and 3.13 (each of which handles CSV quoting slightly differently either when the zhmc command writes the output or when the test functions read the output ):
```
TESTHMC=AHPS make end2end
```
Tests:
- [x] Python 3.13
- [x] Python 3.12
- [x] Python 3.8
