### PR TITLE
Fixed incorrect package version in build; Increased pipdeptree version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,9 +447,9 @@ AUTHORS.md: _always
 	echo "" >>AUTHORS.md.tmp
 	echo "Sorted list of authors derived from git commit history:" >>AUTHORS.md.tmp
 	echo '```' >>AUTHORS.md.tmp
-	sh -c "git shortlog --summary --email HEAD | cut -f 2 | LC_ALL=C.UTF-8 sort >>AUTHORS.md.tmp"
+	bash -c "git shortlog --summary --email HEAD | cut -f 2 | LC_ALL=C.UTF-8 sort >>AUTHORS.md.tmp"
 	echo '```' >>AUTHORS.md.tmp
-	sh -c "if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md as follows:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; rm AUTHORS.md.tmp; fi"
+	bash -c "if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md as follows:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; rm AUTHORS.md.tmp; fi"
 
 .PHONY: uninstall
 uninstall:
@@ -579,13 +579,15 @@ docker: $(done_dir)/docker_$(pymn)_$(PACKAGE_LEVEL).done
 $(sdist_file): Makefile $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(dist_dependent_files)
 	@echo "Makefile: Building the source distribution archive: $(sdist_file)"
 	-$(call RM_FUNC,MANIFEST MANIFEST.in)
-	$(PYTHON_CMD) -m build --sdist --outdir $(dist_dir) .
+	$(PYTHON_CMD) -m build --no-isolation --sdist --outdir $(dist_dir) .
+	bash -c "ls -l $(sdist_file) || ls -l $(dist_dir) && echo package_level=$(package_level) && $(PYTHON_CMD) -m setuptools_scm"
 	@echo "Makefile: Done building the source distribution archive: $(sdist_file)"
 
 $(bdist_file) $(version_file): $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(dist_dependent_files)
 	@echo "Makefile: Building the wheel distribution archive: $(bdist_file)"
 	-$(call RM_FUNC,MANIFEST MANIFEST.in)
-	$(PYTHON_CMD) -m build --wheel --outdir $(dist_dir) -C--universal .
+	$(PYTHON_CMD) -m build --no-isolation --wheel --outdir $(dist_dir) -C--universal .
+	bash -c "ls -l $(bdist_file) $(version_file) || ls -l $(dist_dir) && echo package_level=$(package_level) && $(PYTHON_CMD) -m setuptools_scm"
 	@echo "Makefile: Done building the wheel distribution archive: $(bdist_file)"
 
 $(done_dir)/docker_$(pymn)_$(PACKAGE_LEVEL).done: Makefile $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done Dockerfile .dockerignore $(bdist_file)

--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -7,5 +7,5 @@
 
 pip>=25.0
 setuptools>=70.0.0
-setuptools-scm[toml]>=8.1.0
+setuptools-scm[toml]>=9.2.0
 wheel>=0.41.3

--- a/changes/noissue.1.fix.rst
+++ b/changes/noissue.1.fix.rst
@@ -1,0 +1,7 @@
+Dev: Fixed potential issue where the package version used for distribution
+archive file names possibly could have been generated inconsistently between
+setuptools_scm (used in Makefile) and the 'build' module, by using no build
+isolation ('--no-isolation' option of the 'build' module) and increasing the
+minimum version of 'setuptools-scm' to 9.2.0, which fixes a number of version
+related issues. This issue actually happened in the zhmcclient project, but
+has the potential to show up in this project as well.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -52,7 +52,7 @@ importlib-metadata>=8.7.0; python_version >= '3.9'
 colorama>=0.4.6
 
 # packaging is used by pytest, pip-check-reqs, sphinx, tox
-packaging>=23.2
+packaging>=24.1
 
 # Coverage reporting (no imports, invoked via coveralls script):
 # coveralls versions 4.0.0/4.0.1 have increased their pinning of coverage to <8,
@@ -121,7 +121,7 @@ ruff>=0.3.5
 pluggy>=1.3.0
 
 # Package dependency management tools (not used by any make rules)
-pipdeptree>=2.2.0
+pipdeptree>=2.24.0
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
 # pip-check-reqs 2.5.0 dropped support for py38
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -44,7 +44,7 @@ importlib-metadata==8.5.0; python_version == '3.8'
 importlib-metadata==8.7.0; python_version >= '3.9'
 colorama==0.4.6
 
-packaging==23.2
+packaging==24.1
 
 # Coverage reporting (no imports, invoked via coveralls script):
 coverage==7.6.1; python_version == '3.8'
@@ -101,7 +101,7 @@ ruff==0.3.5
 pluggy==1.3.0  # used by pytest, tox
 
 # Package dependency management tools (not used by any make rules)
-pipdeptree==2.2.0
+pipdeptree==2.24.0
 pip-check-reqs==2.4.3; python_version <= '3.8'
 pip-check-reqs==2.5.1; python_version >= '3.9'
 

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -6,7 +6,7 @@
 pip==25.0
 setuptools==70.0.0
 # Note on not specifying 'setuptools-scm[toml]': Extras cannot be in constraints files
-setuptools-scm==8.1.0
+setuptools-scm==9.2.0
 wheel==0.41.3
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     # Keep in sync with base-requirements.txt and the base dependencies in
     # minimum-constraints-install.txt
     "setuptools>=70.0.0",
-    "setuptools-scm[toml]>=8.1.0",
+    "setuptools-scm[toml]>=9.2.0",
     "wheel>=0.38.1"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
For details, see the commit message.
No review needed.
No rollback to 1.13 needed, because that version is still using setup.py.