### PR TITLE
1.13: Fixed quoting for TESTCASES env var in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ check_py_files := \
 check_reqs_packages := pip_check_reqs virtualenv tox pipdeptree build pytest coverage coveralls flake8 ruff pylint safety bandit sphinx towncrier
 
 ifdef TESTCASES
-  pytest_opts := $(TESTOPTS) -k "$(TESTCASES)"
+  pytest_opts := $(TESTOPTS) -k '$(TESTCASES)'
 else
   pytest_opts := $(TESTOPTS)
 endif

--- a/changes/noissue.2.fix.rst
+++ b/changes/noissue.2.fix.rst
@@ -1,0 +1,1 @@
+Dev: Fixed quoting for TESTCASES env var in Makefile.


### PR DESCRIPTION
Rolls back PR #823 into 1.13.