### PR TITLE
1.13: Circumvented safety issue with import of typer module

### DIFF
--- a/changes/noissue.47.fix.rst
+++ b/changes/noissue.47.fix.rst
@@ -1,0 +1,2 @@
+Dev: Circumvented safety issue with import of typer module by pinning typer
+to <0.17.0.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -34,9 +34,10 @@ ruamel.yaml>=0.17.21
 Authlib>=1.3.1
 marshmallow>=3.15.0
 pydantic>=2.8.0
-typer>=0.12.1
-typer-cli>=0.12.1
-typer-slim>=0.12.1
+# typer >=0.17.0 causes import issue for safety, see https://github.com/pyupio/safety/issues/778
+typer>=0.12.1,<0.17.0
+typer-cli>=0.12.1,<0.17.0
+typer-slim>=0.12.1,<0.17.0
 # safety 3.4.0 depends on psutil~=6.1.0
 psutil~=6.1.0
 


### PR DESCRIPTION
Rolls back PR #825 into 1.13.