### PR TITLE
1.13: Fixed missing display of "cpc-properties" in dpm-export command

### DIFF
--- a/changes/838.fix.rst
+++ b/changes/838.fix.rst
@@ -1,0 +1,3 @@
+Fixed the missing display of "cpc-properties" in the report shown for
+the 'zhmc cpc dpm-export' command, and added a check for future unexpected
+types in the generated config file.

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -1312,11 +1312,13 @@ def _dump_config(config_dict, message):
     values = []
     for k in config_dict:
         v = config_dict[k]
-        if isinstance(v, list):
+        if isinstance(v, (list, dict)):
             counts.append((f'{len(v):>3}', k))
+        elif isinstance(v, (bool, str)):
+            values.append((f'{k}:', v))
         else:
-            if isinstance(v, (bool, str)):
-                values.append((f'{k}:', v))
+            raise TypeError(
+                f"Invalid item type in config dict for key {k}: {type(v)}")
     click.echo(message)
     click.echo(tabulate(counts, [], "plain"))
     click.echo(tabulate(values, [], "plain"))


### PR DESCRIPTION
Rolls back PR #839 into 1.13.