### PR TITLE
Upgrade nltk to 3.9.1 to make it compatible with safety 3.6.1

### DIFF
--- a/changes/noissue.47.fix.1.rst
+++ b/changes/noissue.47.fix.1.rst
@@ -1,0 +1,1 @@
+Upgrade nltk to 3.9.1 to fix the wordnet error, see https://github.com/nltk/nltk/issues/3416

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -132,7 +132,7 @@ keyring==17.0.0
 levenshtein==0.25.1
 MarkupSafe==2.0.0
 more-itertools==5.0.0
-nltk==3.9
+nltk==3.9.1
 pyparsing==3.0.7
 pyproject-api==1.6.1  # used by tox since its 4.0.0
 requests-toolbelt==0.8.0


### PR DESCRIPTION
* Upgrade nltk to 3.9.1 to make it compatible with safety