### PR TITLE
Fixed ReadTheDocs verification steps when making a new release

### DIFF
--- a/changes/noissue.rtd.feature.rst
+++ b/changes/noissue.rtd.feature.rst
@@ -1,0 +1,3 @@
+Docs: Changed the version setup on ReadTheDocs to only show released versions
+and no longer branches such as 'master' or 'stable'. Adjusted the verification
+steps in the release instructions accordingly.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -546,16 +546,32 @@ local clone of the zhmccli Git repo.
     * Verify that the new version has a release on Github at
       https://github.com/zhmcclient/zhmccli/releases
 
-    * Verify that the new version has documentation on ReadTheDocs at
-      https://zhmccli.readthedocs.io/en/latest/changes.html
+10. Verify the documentation on ReadTheDocs
 
-      The new version ``M.N.U`` should be automatically active on ReadTheDocs,
-      causing the documentation for the new version to be automatically
-      built and published.
+    ReadTheDocs automatically activates the new version and sets it as a
+    default version. Branches such as 'master' or 'stable' are no longer
+    shown.
 
-      If you cannot see the new version after some minutes, log in to
-      https://readthedocs.org/projects/zhmccli/versions/
-      and activate the new version.
+    Wait for the ReadTheDocs build for the new version to have completed:
+    https://readthedocs.org/projects/zhmccli/builds/
+
+    Then, perform the following verification:
+
+    * Verify that https://zhmccli.readthedocs.io/ gets redirected to
+      the URL for the new version. This verifies that it has been activated and
+      set as the default version.
+
+11. Hide previous fix version on ReadTheDocs
+
+    When releasing a fix version != 0 (e.g. M.N.1), log on to
+    https://readthedocs.org/accounts/login/, go to
+    https://readthedocs.org/projects/zhmccli/versions/, select to
+    configure the previous fix version (i.e. ``M.N.U-1``) and set it to "hidden"
+    (it remains active).
+
+    Hiding it causes it to be removed from the version list. Keeping it active
+    will ensure that any links to that version that were obtained earlier, still
+    work.
 
 
 .. _`Starting a new version`:


### PR DESCRIPTION
No review needed.