### PR TITLE
1.13: Added pydantic_core dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -33,6 +33,7 @@ ruamel.yaml>=0.17.21
 Authlib>=1.3.1
 marshmallow>=3.15.0
 pydantic>=2.8.0
+pydantic_core>=2.20.0
 #safety 3.6.1 depends on typer>=0.16.0
 typer>=0.16.0
 typer-cli>=0.16.0

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -30,6 +30,7 @@ ruamel.yaml==0.17.21
 Authlib==1.3.1
 marshmallow==3.15.0
 pydantic==2.8.0
+pydantic_core==2.20.0
 typer==0.16.0
 typer-cli==0.16.0
 typer-slim==0.16.0


### PR DESCRIPTION
Rolls back PR #851 into 1.13.