### PR TITLE
Added retries for sending coverage data to the coveralls.io

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,8 +251,12 @@ jobs:
         COVERALLS_SERVICE_NAME: github
         COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
         COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
-      run: |
-        coveralls -v
+      uses: nick-fields/retry@v3
+      with:
+        timeout_seconds: 30
+        max_attempts: 3
+        retry_wait_seconds: 15
+        command: coveralls
     - name: Run check_reqs
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
@@ -291,5 +295,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
-      run: |
-        coveralls -v --finish
+      uses: nick-fields/retry@v3
+      with:
+        timeout_seconds: 30
+        max_attempts: 3
+        retry_wait_seconds: 15
+        command: coveralls --finish

--- a/changes/noissue.coveralls.cleanup.rst
+++ b/changes/noissue.coveralls.cleanup.rst
@@ -1,0 +1,2 @@
+Test: Added retries for sending coverage data to the coveralls.io site to
+address issues with the site.


### PR DESCRIPTION
No review needed.