### PR TITLE
Initial support for SMC-D and HS partition links

### DIFF
--- a/changes/830.feature.rst
+++ b/changes/830.feature.rst
@@ -1,0 +1,5 @@
+Added support for managing partition links with a new ``zhmc partitionlink``
+command group. At this point, only the creation of partition links of types
+"smc-d" and "hipersockets" are supported, but other operations are supported
+for all types. Attaching and detaching partitions to partition links is not
+yet supported.

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -29,7 +29,7 @@ from zhmccli._helper import CmdContext, parse_yaml_flow_style, \
     parse_ec_levels, parse_adapter_names, parse_crypto_domains, \
     domains_to_domain_config, domain_config_to_props_list, \
     required_option, forbidden_option, required_envvar, bool_envvar, \
-    parse_timestamp
+    parse_timestamp, deep_merge
 
 
 # Test cases for parse_yaml_flow_style()
@@ -1272,3 +1272,100 @@ def test_parse_timestamp(value, exp_dt, exp_exc_type, exp_exc_msg):
         dt = parse_timestamp(value)
 
         assert dt == exp_dt
+
+
+TESTCASES_DEEP_MERGE = [
+    # Test cases for deep_merge(). Each item is a testcase with the
+    # following tuple items:
+    # * input_target (object): Input value for 'target' paramneter.
+    # * input_delta (object): Input value for 'delta' paramneter.
+    # * exp_result (object): Expected result.
+
+    (
+        {},
+        {},
+        {},
+    ),
+    (
+        {'a': 1},
+        {},
+        {'a': 1},
+    ),
+    (
+        {},
+        {'a': 1},
+        {'a': 1},
+    ),
+    (
+        {'a': 1},
+        {'b': 2},
+        {'a': 1, 'b': 2},
+    ),
+
+    (
+        {'a': []},
+        {'a': []},
+        {'a': []},
+    ),
+    (
+        {'a': [1]},
+        {'a': [9]},
+        {'a': [9]},
+    ),
+    (
+        {'a': [1, 2]},
+        {'a': [None, 9]},
+        {'a': [1, 9]},
+    ),
+    (
+        {'a': [1]},
+        {'a': [None, 9]},
+        {'a': [1, 9]},
+    ),
+    (
+        {'a': [{'h': 1}, {'i': 2}]},
+        {'a': [None, {'j': 3}]},
+        {'a': [{'h': 1}, {'i': 2, 'j': 3}]},
+    ),
+
+    (
+        [],
+        [],
+        [],
+    ),
+    (
+        [1],
+        [9],
+        [9],
+    ),
+    (
+        [1],
+        [None, 9],
+        [1, 9],
+    ),
+    (
+        [1, 2],
+        [None, 9],
+        [1, 9],
+    ),
+    (
+        [{'h': 1}, {'i': 2}],
+        [None, {'j': 3}],
+        [{'h': 1}, {'i': 2, 'j': 3}],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_target, input_delta, exp_result",
+    TESTCASES_DEEP_MERGE)
+def test_deep_merge(input_target, input_delta, exp_result):
+    """
+    Test function for deep_merge().
+    """
+
+    # The function to be tested
+    result = deep_merge(input_target, input_delta)
+
+    assert result == exp_result
+    assert input_target == exp_result

--- a/zhmccli/__init__.py
+++ b/zhmccli/__init__.py
@@ -29,6 +29,7 @@ from ._cmd_resetprofile import *   # noqa: F401
 from ._cmd_imageprofile import *   # noqa: F401
 from ._cmd_loadprofile import *   # noqa: F401
 from ._cmd_partition import *  # noqa: F401
+from ._cmd_partitionlink import *  # noqa: F401
 from ._cmd_adapter import *    # noqa: F401
 from ._cmd_port import *       # noqa: F401
 from ._cmd_hba import *        # noqa: F401

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -72,6 +72,22 @@ def find_adapter(cmd_ctx, client, cpc_name, adapter_name):
     return adapter
 
 
+def find_adapter_by_uri(cmd_ctx, cpc, adapter_uri):
+    """
+    Find an adapter by URI and return its resource object.
+
+    The list of adapters of the CPC is cached.
+    """
+    if not hasattr(find_adapter_by_uri, 'cpcs'):
+        find_adapter_by_uri.adapters = {a.uri: a for a in cpc.adapters.list()}
+
+    try:
+        return find_adapter_by_uri.adapters[adapter_uri]
+    except KeyError:
+        exc = zhmcclient.NotFound({'object-uri': adapter_uri}, cpc.adapters)
+        raise click_exception(exc, cmd_ctx.error_format)
+
+
 @cli.group('adapter', options_metavar=COMMAND_OPTIONS_METAVAR)
 def adapter_group():
     """

--- a/zhmccli/_cmd_cpc.py
+++ b/zhmccli/_cmd_cpc.py
@@ -171,6 +171,22 @@ def find_cpc(cmd_ctx, client, cpc_name):
     return cpc
 
 
+def find_cpc_by_uri(cmd_ctx, client, cpc_uri):
+    """
+    Find a CPC by URI and return its resource object.
+
+    The list of CPCs is cached.
+    """
+    if not hasattr(find_cpc_by_uri, 'cpcs'):
+        find_cpc_by_uri.cpcs = {cpc.uri: cpc for cpc in client.cpcs.list()}
+
+    try:
+        return find_cpc_by_uri.cpcs[cpc_uri]
+    except KeyError:
+        exc = zhmcclient.NotFound({'object-uri': cpc_uri}, client.cpcs)
+        raise click_exception(exc, cmd_ctx.error_format)
+
+
 def find_cpc_hwmessage(cmd_ctx, cpc, message_id):
     """
     Find a Hardware messae of a CPC and return its resource object.

--- a/zhmccli/_cmd_partitionlink.py
+++ b/zhmccli/_cmd_partitionlink.py
@@ -1,0 +1,635 @@
+# Copyright 2025 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Commands for partition links in DPM mode.
+"""
+
+
+import click
+from click_option_group import optgroup
+
+import zhmcclient
+from .zhmccli import cli
+from ._helper import print_properties, print_resources, abort_if_false, \
+    options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
+    click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
+    build_filter_args, SORT_OPTIONS, build_sort_props, ALL_PARTITION_STATUSES
+from ._cmd_cpc import find_cpc, find_cpc_by_uri
+from ._cmd_adapter import find_adapter_by_uri
+
+
+# Defaults for partition link creation
+PARTITIONLINK_TYPES = ['hipersockets', 'smc-d']  # 'ctc' is not yet supported
+DEFAULT_PARTITIONLINK_TYPE = 'hipersockets'
+DEFAULT_SMCD_STARTING_FID = 4096
+DEFAULT_HS_STARTING_DEVNO = 7400
+DEFAULT_HS_MTU_SIZE = 8
+# DEFAULT_CTC_DEVICES_PER_PATH = 4
+
+
+def find_partitionlink(cmd_ctx, client, partitionlink_name):
+    """
+    Find a partition link by name and return its resource object.
+    """
+    console = client.consoles.console
+    try:
+        partitionlink = console.partition_links.find(name=partitionlink_name)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    return partitionlink
+
+
+@cli.group('partitionlink', options_metavar=COMMAND_OPTIONS_METAVAR)
+def partitionlink_group():
+    """
+    Command group for managing partition links (DPM mode only).
+
+    The commands in this group work only on CPCs that are in DPM mode.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+
+
+@partitionlink_group.command('list', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='[CPC]', required=False)
+@add_options(LIST_OPTIONS)
+@add_options(FILTER_OPTIONS)
+@add_options(SORT_OPTIONS)
+@click.pass_obj
+def partitionlink_list(cmd_ctx, cpc, **options):
+    """
+    List the partition links associated with a CPC, or all partition links.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_partitionlink_list(cmd_ctx, cpc, options))
+
+
+@partitionlink_group.command('show', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('PARTITIONLINK', type=str, metavar='PARTITIONLINK')
+@click.pass_obj
+def partitionlink_show(cmd_ctx, partitionlink):
+    # pylint: disable=line-too-long
+    """
+    Show the details of a partition link.
+
+    The following properties are shown in addition to those returned by the HMC:
+
+    \b
+      - 'adapter-name' - Name of the backing adapter, for SMC-D and Hipersocket.
+      - 'bus-connections.nics.nic-name' - Names of the NICs, for SMC-D and Hipersocket.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """  # noqa: E501
+    cmd_ctx.execute_cmd(
+        lambda: cmd_partitionlink_show(cmd_ctx, partitionlink))
+
+
+@partitionlink_group.command('create', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('CPC', type=str, metavar='CPC')
+@optgroup.group('General options')
+@optgroup.option('--name', type=str, required=True,
+                 help='The name of the new partition link.')
+@optgroup.option('--type', type=click.Choice(PARTITIONLINK_TYPES),
+                 required=False, default=DEFAULT_PARTITIONLINK_TYPE,
+                 help='The type of the new partition link. Default: {d}'.
+                 format(d=DEFAULT_PARTITIONLINK_TYPE))
+@optgroup.option('--description', type=str, required=False,
+                 help='The description of the new partition link.')
+@optgroup.group('For type=hipersockets')
+@optgroup.option('--starting-devno', type=str, required=False,
+                 help='The starting number for the device number assignment, '
+                 'acting as a default. If no device number for a NIC is '
+                 'provided when adding a partition, the next available '
+                 'device number starting from this value will be used. '
+                 'Default: {d}'.format(d=DEFAULT_HS_STARTING_DEVNO))
+@optgroup.option('--mtu-size', type=int, required=False,
+                 help='The maximum transmission unit (MTU) size of the '
+                 'Hipersockets adapter that will be created. The maximum frame '
+                 'size is implied by this value. Valid values are: '
+                 '8 - 8 KB MTU size and 16 KB maximum frame size; '
+                 '16 - 16 KB MTU size and 24 KB maximum frame size; '
+                 '32 - 32 KB MTU size and 40 KB maximum frame size; '
+                 '56 - 56 KB MTU size and 64 KB maximum frame size. '
+                 'Default: {d}'.format(d=DEFAULT_HS_MTU_SIZE))
+@optgroup.group('For type=smc-d')
+@optgroup.option('--starting-fid', type=int, required=False,
+                 help='The starting number for the Functional ID (FID) '
+                 'assignment, acting as a default. If no FID for a NIC is '
+                 'provided when adding a partition, the next available FID '
+                 'starting from this value will be used. '
+                 'Default: {d}'.format(d=DEFAULT_SMCD_STARTING_FID))
+# @optgroup.group('For type=ctc')
+# @optgroup.option('--devices-per-path', type=int, required=False,
+#                  help='The number of devices to be created per path when '
+#                  'adding a partition. '
+#                  'Default: {d}'.format(d=DEFAULT_CTC_DEVICES_PER_PATH))
+@click.pass_obj
+def partitionlink_create(cmd_ctx, cpc, **options):
+    """
+    Create a partition link associated with a CPC.
+
+    This command cannot be used to have partitions attached to the new
+    partition link.
+
+    This command supports only the creation of partitions links of type SMC-D
+    and Hipersockets; type CTC is not supported.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(lambda: cmd_partitionlink_create(cmd_ctx, cpc, options))
+
+
+@partitionlink_group.command('update', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('PARTITIONLINK', type=str, metavar='PARTITIONLINK')
+@optgroup.group('General options')
+@optgroup.option('--name', type=str, required=False,
+                 help='The new name of the partition link.')
+@optgroup.option('--description', type=str, required=False,
+                 help='The new description of the partition link.')
+@optgroup.group('For type=hipersockets')
+@optgroup.option('--starting-devno', type=str, required=False,
+                 help='The new starting number for the device number '
+                 'assignment, acting as a default. If no device number for a '
+                 'NIC is provided when adding a partition, the next available '
+                 'device number starting from this value will be used.')
+@optgroup.option('--mtu-size', type=int, required=False,
+                 help='The new maximum transmission unit (MTU) size for the '
+                 'Hipersockets adapter. The maximum frame '
+                 'size is implied by this value. Valid values are: '
+                 '8 - 8 KB MTU size and 16 KB maximum frame size; '
+                 '16 - 16 KB MTU size and 24 KB maximum frame size; '
+                 '32 - 32 KB MTU size and 40 KB maximum frame size; '
+                 '56 - 56 KB MTU size and 64 KB maximum frame size.')
+@optgroup.group('For type=smc-d')
+@optgroup.option('--starting-fid', type=int, required=False,
+                 help='The new starting number for the Functional ID (FID) '
+                 'assignment, acting as a default. If no FID for a NIC is '
+                 'provided when adding a partition, the next available FID '
+                 'starting from this value will be used.')
+# @optgroup.group('For type=ctc')
+# @optgroup.option('--devices-per-path', type=int, required=False,
+#                  help='Number of devices to be created per path when adding '
+#                  'a partition. '
+#                  'Default: {d}'.format(d=DEFAULT_CTC_DEVICES_PER_PATH))
+@click.pass_obj
+def partitionlink_update(cmd_ctx, partitionlink, **options):
+    """
+    Update the properties of a partition link.
+
+    This command cannot be used to attach or detach partitions to or from
+    a partition link.
+
+    The partition link type and the associated CPC cannot be changed once a
+    partition link has been created.
+
+    Only the properties will be changed for which a corresponding option is
+    specified, so the default for all options is not to change properties.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(
+        lambda: cmd_partitionlink_update(cmd_ctx, partitionlink, options))
+
+
+@partitionlink_group.command('delete', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('PARTITIONLINK', type=str, metavar='PARTITIONLINK')
+@click.option('-y', '--yes', is_flag=True, callback=abort_if_false,
+              expose_value=False,
+              help='Skip prompt to confirm deletion of the partition link.',
+              prompt='Are you sure you want to delete this partition link ?')
+@click.pass_obj
+def partitionlink_delete(cmd_ctx, partitionlink):
+    """
+    Delete a partition link.
+
+    For Hipersocket partition links, this will cause the NICs that belong to
+    the partition link to be deleted in the linked partitions.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(
+        lambda: cmd_partitionlink_delete(cmd_ctx, partitionlink))
+
+
+@partitionlink_group.command(
+    'list-partitions', options_metavar=COMMAND_OPTIONS_METAVAR)
+@click.argument('PARTITIONLINK', type=str, metavar='PARTITIONLINK')
+@add_options(LIST_OPTIONS)
+@click.option('--name', type=str, required=False,
+              help="Regular expression filter to limit the returned partitions "
+              "to those with a matching name.")
+@click.option('--status', type=str, required=False,
+              help="Filter to limit the returned partitions to those with a "
+              "matching status. Valid status values are: {sv}.".
+              format(sv=', '.join(ALL_PARTITION_STATUSES)))
+@add_options(SORT_OPTIONS)
+@click.pass_obj
+def partitionlink_list_partitions(cmd_ctx, partitionlink, **options):
+    """
+    List the partitions attached to a partition link.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(
+        lambda: cmd_partitionlink_list_partitions(
+            cmd_ctx, partitionlink, options))
+
+
+@partitionlink_group.command(
+    'attach-partition', options_metavar=COMMAND_OPTIONS_METAVAR,
+    hidden=True)  # TODO: Implement in zhmcclient
+@click.argument('PARTITIONLINK', type=str, metavar='PARTITIONLINK')
+@click.option('--partition', type=str, required=True,
+              help='The name of the partition.')
+@click.pass_obj
+def partitionlink_attach_partition(cmd_ctx, partitionlink, **options):
+    """
+    Attach a partition to a partition link.
+
+    For Hipersocket partition links, this will cause one or more NICs to be
+    created in the attached partition.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(
+        lambda: cmd_partitionlink_attach_partition(
+            cmd_ctx, partitionlink, options))
+
+
+@partitionlink_group.command(
+    'detach-partition', options_metavar=COMMAND_OPTIONS_METAVAR,
+    hidden=True)  # TODO: Implement in zhmcclient
+@click.argument('PARTITIONLINK', type=str, metavar='PARTITIONLINK')
+@click.option('--partition', type=str, required=True,
+              help='The name of the partition.')
+@click.pass_obj
+def partitionlink_detach_partition(cmd_ctx, partitionlink, **options):
+    """
+    Detach a partition from a partition link.
+
+    For Hipersocket partition links, this will cause the NICs that belong to
+    the partition link to be deleted in the detached partition.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified right after the
+    'zhmc' command name.
+    """
+    cmd_ctx.execute_cmd(
+        lambda: cmd_partitionlink_detach_partition(
+            cmd_ctx, partitionlink, options))
+
+
+def cmd_partitionlink_list(cmd_ctx, cpc_name, options):
+    # pylint: disable=missing-function-docstring
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    console = client.consoles.console
+
+    show_list = [
+        'cpc',
+        'name',
+    ]
+    if not options['names_only']:
+        show_list.extend([
+            'type',
+            'state',
+            'description',
+        ])
+    if options['uri']:
+        show_list.extend([
+            'object-uri',
+        ])
+    # TODO: Add adapter-name in case of --all
+    # if options['all']:
+    #     show_list.extend([
+    #         'adapter-name',
+    #     ])
+
+    # Make sure to include only properties in additional properties
+    # that are known resource properties and are not included in the
+    # default set of properties for a list operation.
+    standard_props = ['cpc', 'name', 'type', 'state', 'object-uri']
+    additional_props = [p for p in show_list if p not in standard_props]
+
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
+
+    if cpc_name:  # None if not specified
+        cpc = find_cpc(cmd_ctx, client, cpc_name)
+        if filter_args is None:
+            filter_args = {}
+        filter_args['cpc-uri'] = cpc.uri
+
+    try:
+        partitionlinks = console.partition_links.list(
+            additional_properties=additional_props, filter_args=filter_args)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    # Prepare the additions dict of dicts. It contains additional
+    # (=non-resource) property values by property name and by resource URI.
+    additions = {}
+    updates = {}
+
+    # Add artificial property 'cpc':
+    additions['cpc'] = {}
+    for pl in partitionlinks:
+        cpc_uri = pl.get_property('cpc-uri')
+        cpc = find_cpc_by_uri(cmd_ctx, client, cpc_uri)
+        additions['cpc'][pl.uri] = cpc.name
+
+    if options['all']:
+        additions['adapter-name'] = {}
+        updates['bus-connections'] = {}
+        for pl in partitionlinks:
+
+            # Add artificial property 'adapter-name':
+            adapter_uri = pl.prop('adapter-uri', None)
+            if adapter_uri:  # Exists only for SMC-D and Hipersocket type
+                cpc_uri = pl.get_property('cpc-uri')
+                cpc = find_cpc_by_uri(cmd_ctx, client, cpc_uri)
+                adapter = find_adapter_by_uri(cmd_ctx, cpc, adapter_uri)
+                additions['adapter-name'][pl.uri] = adapter.name
+
+            # Add artificial property 'nic-name' in 'bus-connections.nics':
+            bc_list = pl.prop('bus-connections', None)
+            if bc_list:  # Exists only for SMC-D and Hipersocket type
+                updates_bc_list = []
+                for bc_item in bc_list:
+                    nic_items = bc_item['nics']
+                    updates_nics = []
+                    for nic_item in nic_items:
+                        nic_uri = nic_item['nic-uri']
+                        nic_props = client.session.get(nic_uri)
+                        updates_nics.append({'nic-name': nic_props['name']})
+                    updates_bc_list.append({'nics': updates_nics})
+                updates['bus-connections'][pl.uri] = updates_bc_list
+
+    sort_props = build_sort_props(cmd_ctx, options['sort'],
+                                  default=['cpc', 'name'])
+
+    try:
+        print_resources(
+            cmd_ctx, partitionlinks, cmd_ctx.output_format, show_list,
+            additions, all=options['all'], sort_props=sort_props,
+            updates=updates)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+
+def cmd_partitionlink_show(cmd_ctx, partitionlink_name):
+    # pylint: disable=missing-function-docstring
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    partitionlink = find_partitionlink(cmd_ctx, client, partitionlink_name)
+
+    try:
+        partitionlink.pull_full_properties()
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    properties = dict(partitionlink.properties)
+
+    # Add artificial property 'adapter-name':
+    adapter_uri = properties.get('adapter-uri', None)
+    if adapter_uri:  # Exists only for SMC-D and Hipersocket type
+        cpc_uri = properties['cpc-uri']
+        cpc = find_cpc_by_uri(cmd_ctx, client, cpc_uri)
+        adapter = find_adapter_by_uri(cmd_ctx, cpc, adapter_uri)
+        properties['adapter-name'] = adapter.name
+
+    # Add artificial property 'nic-name' in 'bus-connections.nics':
+    bc_list = properties.get('bus-connections', None)
+    if bc_list:  # Exists only for SMC-D and Hipersocket type
+        for bc_item in bc_list:
+            nic_items = bc_item['nics']
+            for nic_item in nic_items:
+                nic_uri = nic_item['nic-uri']
+                nic_props = client.session.get(nic_uri)
+                nic_item['nic-name'] = nic_props['name']
+
+    # # Hide some long or deeply nested properties in table output formats.
+    # if not options['all'] and cmd_ctx.output_format in TABLE_FORMATS:
+    #     hide_property(properties, 'xxxxxxxxx')
+
+    print_properties(cmd_ctx, properties, cmd_ctx.output_format)
+
+
+def cmd_partitionlink_create(cmd_ctx, cpc_name, options):
+    # pylint: disable=missing-function-docstring
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    console = client.consoles.console
+    cpc = find_cpc(cmd_ctx, client, cpc_name)
+
+    name_map = {
+        'starting-devno': 'starting-device-number',
+        'mtu-size': 'maximum-transmission-unit-size',
+    }
+
+    org_options = original_options(options)
+    properties = options_to_properties(org_options, name_map)
+
+    properties['cpc-uri'] = cpc.uri
+
+    try:
+        new_partitionlink = console.partition_links.create(properties)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    cmd_ctx.spinner.stop()
+    click.echo("New partition link '{p}' has been created.".
+               format(p=new_partitionlink.properties['name']))
+
+
+def cmd_partitionlink_update(cmd_ctx, partitionlink_name, options):
+    # pylint: disable=missing-function-docstring
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    partitionlink = find_partitionlink(cmd_ctx, client, partitionlink_name)
+
+    name_map = {
+        'starting-devno': 'starting-device-number',
+        'mtu-size': 'maximum-transmission-unit-size',
+    }
+
+    org_options = original_options(options)
+    properties = options_to_properties(org_options, name_map)
+
+    if not properties:
+        cmd_ctx.spinner.stop()
+        click.echo("No properties specified for updating partition link '{p}'.".
+                   format(p=partitionlink_name))
+        return
+
+    try:
+        partitionlink.update_properties(properties)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    cmd_ctx.spinner.stop()
+    if 'name' in properties and properties['name'] != partitionlink_name:
+        click.echo("Partition link '{pl}' has been renamed to '{pln}' and was "
+                   "updated.".
+                   format(pl=partitionlink_name, pln=properties['name']))
+    else:
+        click.echo(f"Partition link '{partitionlink_name}' has been updated.")
+
+
+def cmd_partitionlink_delete(cmd_ctx, partitionlink_name):
+    # pylint: disable=missing-function-docstring
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    partitionlink = find_partitionlink(cmd_ctx, client, partitionlink_name)
+
+    try:
+        partitionlink.delete()
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    cmd_ctx.spinner.stop()
+    click.echo(f"Partition link '{partitionlink_name}' has been deleted.")
+
+
+def cmd_partitionlink_list_partitions(cmd_ctx, partitionlink_name, options):
+    # pylint: disable=missing-function-docstring
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    partitionlink = find_partitionlink(cmd_ctx, client, partitionlink_name)
+
+    show_list = [
+        'cpc',
+        'name',
+    ]
+    if not options['names_only']:
+        show_list.extend([
+            'type',
+            'status',
+            'description',
+            'nics',
+        ])
+    if options['uri']:
+        show_list.extend([
+            'object-uri',
+        ])
+
+    name_filter = options['name']
+    status_filter = options['status']
+    try:
+        partitions = partitionlink.list_attached_partitions(
+            name=name_filter, status=status_filter)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    # Prepare the additions dict of dicts. It contains additional
+    # (=non-resource) property values by property name and by resource URI.
+    additions = {}
+
+    # Add artificial property 'cpc':
+    additions['cpc'] = {}
+    for p in partitions:
+        cpc = p.manager.parent
+        additions['cpc'][p.uri] = cpc.name
+
+    if partitionlink.get_property('type') in ('smc-d', 'hipersockets'):
+        # Add artificial property 'nics':
+        additions['nics'] = {}
+        for p in partitions:
+            bc_list = partitionlink.get_property('bus-connections')
+            for bc_item in bc_list:
+                if bc_item['partition-name'] == p.name:
+                    nic_items = bc_item['nics']
+                    additions['nics'][p.uri] = []
+                    for nic_item in nic_items:
+                        nic_uri = nic_item['nic-uri']
+                        nic_props = client.session.get(nic_uri)
+                        additions['nics'][p.uri].append(nic_props['name'])
+
+    sort_props = build_sort_props(cmd_ctx, options['sort'],
+                                  default=['cpc', 'name'])
+
+    try:
+        print_resources(
+            cmd_ctx, partitions, cmd_ctx.output_format, show_list,
+            additions, all=options['all'], sort_props=sort_props)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+
+def cmd_partitionlink_attach_partition(cmd_ctx, partitionlink_name, options):
+    # pylint: disable=missing-function-docstring
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    partitionlink = find_partitionlink(cmd_ctx, client, partitionlink_name)
+
+    cpc_uri = partitionlink.get_property('cpc-uri')
+    cpc = client.cpcs.find(**{'object-uri': cpc_uri})
+
+    partition_name = options['partition']  # Required
+    try:
+        partition = cpc.partitions.find(name=partition_name)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    try:
+        partitionlink.attach_partition(partition)  # TODO: Implement
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    cmd_ctx.spinner.stop()
+    click.echo("Partition '{p}' was attached to partition link '{pl}'.".
+               format(p=partition_name, pl=partitionlink.name))
+
+
+def cmd_partitionlink_detach_partition(cmd_ctx, partitionlink_name, options):
+    # pylint: disable=missing-function-docstring
+
+    client = zhmcclient.Client(cmd_ctx.session)
+    partitionlink = find_partitionlink(cmd_ctx, client, partitionlink_name)
+
+    cpc_uri = partitionlink.get_property('cpc-uri')
+    cpc = client.cpcs.find(**{'object-uri': cpc_uri})
+
+    partition_name = options['partition']  # Required
+    try:
+        partition = cpc.partitions.find(name=partition_name)
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    try:
+        partitionlink.detach_partition(partition)  # TODO: Implement
+    except zhmcclient.Error as exc:
+        raise click_exception(exc, cmd_ctx.error_format)
+
+    cmd_ctx.spinner.stop()
+    click.echo("Partition '{p}' was detached from partition link '{pl}'.".
+               format(p=partition_name, pl=partitionlink.name))

--- a/zhmccli/_cmd_storagegroup.py
+++ b/zhmccli/_cmd_storagegroup.py
@@ -27,22 +27,10 @@ from ._helper import print_properties, print_resources, abort_if_false, \
     options_to_properties, original_options, COMMAND_OPTIONS_METAVAR, \
     click_exception, add_options, LIST_OPTIONS, FILTER_OPTIONS, \
     build_filter_args, SORT_OPTIONS, build_sort_props, EMAIL_OPTIONS, \
-    ASYNC_TIMEOUT_OPTIONS
+    ASYNC_TIMEOUT_OPTIONS, ALL_PARTITION_STATUSES
 
 
 ALL_TYPES = ['fcp', 'fc']
-ALL_PARTITION_STATUSES = [
-    "communications-not-active",
-    "status-check",
-    "stopped",
-    "terminated",
-    "starting",
-    "active",
-    "stopping",
-    "degraded",
-    "reservation-error",
-    "paused",
-]
 
 # Defaults for storage group creation unless created from storage template
 DEFAULT_TYPE = 'fcp'


### PR DESCRIPTION
For details, see the commit message or the change log entry.

Tested manually in POK:
```
zhmc partitionlink create B151 --name test_hs1
zhmc partitionlink list
zhmc partitionlink list B151
zhmc partitionlink list B151 --all
zhmc partitionlink show test_hs1
zhmc partitionlink list-partitions test_hs1
zhmc partitionlink delete -y test_hs1
zhmc partitionlink show HPVS-HS1
zhmc partitionlink list-partitions HPVS-HS1
zhmc partitionlink list-partitions HPVS-HS1 --name b151-12
zhmc partitionlink list-partitions HPVS-HS1 --status active
zhmc partitionlink list-partitions HPVS-HS1 --all
```
Because of the changes on how "additions" is treated in `get_resource_list()`, I also tested listing of all resource classes that use "additions" (except vfunction and hba) with and without `--all` (where supported) and other options that add columns:
```
zhmc -o json adapter list B151 | jq                                # additions: cpc
zhmc -o json adapter list B151 --all | jq                          # additions: cpc
zhmc -o json capacitygroup list B151 | jq                          # additions: cpc, partitions
zhmc -o json capacitygroup list B151 --all | jq                    # additions: cpc, partitions
zhmc -o json passwordrule characterrule list Basic | jq            # additions: index
zhmc -o json console get-audit-log --begin 2025-10-23 | jq         # additions: timestamp
zhmc -o json console get-security-log --begin 2025-10-23 | jq      # additions: timestamp
zhmc -o json console hw-message list --begin 2025-10-23 | jq       # additions: timestamp-utc, message-id
zhmc -o json cpc hw-message list B151 --begin 2025-10-23 | jq      # additions: timestamp-utc, message-id
zhmc -o json nic list B151 b151-03 | jq                            # additions: cpc, partition
zhmc -o json nic list B151 b151-03 --all | jq                      # additions: cpc, partition
zhmc -o json partition list B151 --filter name=b151-03 --ifl-usage | jq    # additions: cpc, ifl-capacity, ifls, ifl-weight, processor-usage, processors-used, and some more
zhmc -o json port list B151 OSA1 | jq                              # additions: cpc, adapter
zhmc -o json port list B151 OSA1 --all | jq                        # additions: cpc, adapter
zhmc -o json storagegroup list B151 | jq                           # additions: cpc
zhmc -o json storagegroup list B151 --all | jq                     # additions: cpc
zhmc -o json storagegroup list-partitions B151_SG_b151-03 | jq     # additions: cpc
zhmc -o json storagegroup list-ports B151_SG_b151-03 | jq          # additions: cpc, adapter
zhmc -o json storagevolume list B151_SG_b151-03 | jq               # additions: storagegroup
zhmc -o json storagevolume list B151_SG_b151-03 --all | jq         # additions: storagegroup
zhmc -o json userrole list | jq                                    # additions: permissions
zhmc -o json userrole list --permissions | jq                      # additions: permissions
zhmc -o json user list --filter name=ACSADMIN | jq                 # additions: roles, password-rule
zhmc -o json user list --filter name=ACSADMIN --all | jq           # additions: roles, password-rule
zhmc -o json user list --filter name=ACSADMIN --permissions | jq   # additions: roles, password-rule
zhmc -o json user list --filter name=ACSADMIN --status | jq        # additions: roles, password-rule
zhmc -o json vstorageresource list B151_SG_b151-03 | jq            # additions: storagegroup, partition, adapter, port, wwpn, wwpn-status
zhmc -o json vstorageresource list B151_SG_b151-03 --all | jq      # additions: storagegroup, partition, adapter, port, wwpn, wwpn-status
```