### PR TITLE
1.14: Clarified safety ignore-unpinned; Addressed safety issues

### DIFF
--- a/.safety-policy-develop.yml
+++ b/.safety-policy-develop.yml
@@ -18,7 +18,9 @@ security:
     ignore-cvss-unknown-severity: False
 
     # Ignore unpinned requirements.
-    # Should be set to False.
+    # Default is true. "Unpinned" in this case means anything else but "==".
+    # Since we are checking against the minimum-constraints file, this check
+    # is enabled (false).
     ignore-unpinned-requirements: False
 
     # List of specific vulnerabilities to ignore.
@@ -38,6 +40,8 @@ security:
             reason: Fixed authlib version 1.6.5 requires Python>=3.9 and is used there
         81132:
             reason: Fixed authlib version 1.6.5 requires Python>=3.9 and is used there
+        83159:
+            reason: Fixed marshmallow version 3.26.2 requires Python>=3.9 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -18,7 +18,9 @@ security:
     ignore-cvss-unknown-severity: False
 
     # Ignore unpinned requirements.
-    # Should be set to False.
+    # Default is true. "Unpinned" in this case means anything else but "==".
+    # Since we are checking against the minimum-constraints file, this check
+    # is enabled (false).
     ignore-unpinned-requirements: False
 
     # List of specific vulnerabilities to ignore.
@@ -42,6 +44,8 @@ security:
             reason: Fixed urllib3 version 2.6.0 requires Python>=3.9 and is used there
         82332:
             reason: Fixed urllib3 version 2.6.0 requires Python>=3.9 and is used there
+        84031:
+            reason: Fixed urllib3 version 2.6.3 requires Python>=3.9 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -34,7 +34,8 @@ ruamel.yaml>=0.17.21
 # click is covered in requirements.txt
 Authlib>=1.3.2; python_version == '3.8'
 Authlib>=1.6.5; python_version >= '3.9'
-marshmallow>=3.15.0
+marshmallow>=3.15.0; python_version == '3.8'
+marshmallow>=3.26.2; python_version >= '3.9'
 pydantic>=2.10.6; python_version == '3.8'
 pydantic>=2.12.0; python_version >= '3.9'
 pydantic_core>=2.27.2; python_version == '3.8'

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -29,7 +29,8 @@ ruamel.yaml==0.17.21
 # click is covered in requirements.txt
 Authlib==1.3.2; python_version == '3.8'
 Authlib==1.6.5; python_version >= '3.9'
-marshmallow==3.15.0
+marshmallow==3.15.0; python_version == '3.8'
+marshmallow==3.26.2; python_version >= '3.9'
 pydantic==2.10.6; python_version == '3.8'
 pydantic==2.12.0; python_version >= '3.9'
 pydantic_core==2.27.2; python_version == '3.8'

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -36,7 +36,7 @@ yamlloader==0.5.5
 
 # urllib3 is used to disable warnings
 urllib3==2.2.3; python_version == '3.8'
-urllib3==2.6.0; python_version >= '3.9'
+urllib3==2.6.3; python_version >= '3.9'
 
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with requirements.txt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ jsonschema>=4.18.0
 yamlloader>=0.5.5
 
 urllib3>=2.2.3; python_version == '3.8'
-urllib3>=2.6.0; python_version >= '3.9'
+urllib3>=2.6.3; python_version >= '3.9'
 
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with minimum-constraints-install.txt)


### PR DESCRIPTION
Rolls back PR #895 into 1.14.