### PR TITLE
1.14: Enabled safety IDs starting with 'SFTY-' again

### DIFF
--- a/.safety-policy-develop.yml
+++ b/.safety-policy-develop.yml
@@ -46,11 +46,10 @@ security:
             reason: Fixed filelock version 3.20.3 requires Python>=3.10 and is used there
         84415:
             reason: Fixed filelock version 3.20.3 requires Python>=3.10 and is used there
-        # Need to comment out due to issue https://github.com/pyupio/safety/issues/847
-        # SFTY-20260218-01424:
-        #     reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
         84339:
             reason: Fixed authlib version 1.6.6 requires Python>=3.9 and is used there
+        88424:
+            reason: Fixed by upgrading authlib from 1.6.5 to 1.6.7 for Python>=3.9 (CVE-2026-28802 - JWT alg none vulnerability)
         89482:
             reason: Fixed authlib version 1.6.9 requires Python>=3.10 and is used there
         89483:
@@ -59,6 +58,8 @@ security:
             reason: Fixed authlib version 1.6.9 requires Python>=3.10 and is used there
         90553:
             reason: Fixed requests version 2.33.0 requires Python>=3.10 and is used there
+        SFTY-20260218-01424:
+            reason: Fixed nltk version 3.9.3 requires Python>=3.10 and is used there
         SFTY-20260122-20373:
            reason: Fixed pytest version 9.0.3 requires Python>=3.10 and is used there
         SFTY-20260322-35073:

--- a/changes/noissue.99.fix.rst
+++ b/changes/noissue.99.fix.rst
@@ -1,0 +1,2 @@
+Enabled safety IDs starting with "SFTY-" again since they are now supported
+by the 'safety check' command.

--- a/changes/noissue.safety.fix.rst
+++ b/changes/noissue.safety.fix.rst
@@ -1,1 +1,1 @@
-Fixed safety issues up to 2026-05-06.
+Fixed safety issues up to 2026-05-22.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -143,6 +143,7 @@ keyring==17.0.0
 levenshtein==0.25.1
 MarkupSafe==2.0.0
 more-itertools==5.0.0
+nltk==3.9.2; python_version == '3.9'
 nltk==3.9.4; python_version >= '3.10'
 pyparsing==3.0.7
 pyproject-api==1.6.1  # used by tox since its 4.0.0


### PR DESCRIPTION
Rolls back PR #931 into 1.14.