### PR TITLE
1.14: Relaxed the commit message length check in the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: gsactions/commit-message-checker@v2
       with:
-        pattern: '^.{1,80}\n\n(.{0,80}\n)*.{0,80}$'
+        pattern: '^.{1,80}( \(#[\d]+\))?\n(.{0,80}\n)*'
         flags: ''
         excludeDescription: true
         excludeTitle: true

--- a/changes/noissue.98.fix.rst
+++ b/changes/noissue.98.fix.rst
@@ -1,0 +1,3 @@
+Relaxed the commit message length check in the test workflow so
+that it no longer requires an empty line after the title and that it
+ignores the PR ID created by squash commits when checking the length.


### PR DESCRIPTION
Backported PR #937 into 1.14.