### PR TITLE
1.14: Fixed safety issues and added truststore as a dev dependency

### DIFF
--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -60,6 +60,8 @@ security:
             reason: Fixed requests version 2.33.0 requires Python>=3.10 and is used there
 
         # Need to comment out SFTY IDs due to issue https://github.com/pyupio/safety/issues/847
+        # SFTY-20260511-47957:
+        #     reason: Fixed urllib3 version 2.7.0 requires Python>=3.10 and is used there
         # SFTY-20260420-60812:
         #     reason: Fixed pip version 26.1 requires Python>=3.10 and is used there
 

--- a/changes/noissue.safety.fix.rst
+++ b/changes/noissue.safety.fix.rst
@@ -1,1 +1,1 @@
-Fixed safety issues up to 2026-05-22.
+Fixed safety issues up to 2026-06-17.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -40,6 +40,7 @@ typer==0.16.0
 typer-cli==0.16.0
 typer-slim==0.16.0
 psutil==6.1.0
+truststore==0.9.1
 
 # Bandit checker
 bandit==1.7.8

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -39,8 +39,10 @@ jsonschema==4.18.0
 yamlloader==0.5.5
 
 # urllib3 is used to disable warnings
-urllib3==2.2.3; python_version == '3.8'
-urllib3==2.6.3; python_version == '3.9'
+# Need to comment out urllib3==2.2.3 due to issue https://github.com/pyupio/safety/issues/847
+# urllib3==2.2.3; python_version == '3.8'
+# Need to comment out urllib3==2.6.3 due to issue https://github.com/pyupio/safety/issues/847
+# urllib3==2.6.3; python_version == '3.9'
 urllib3==2.7.0; python_version >= '3.10'
 
 


### PR DESCRIPTION
Backport PR #944 to 1.14.