### PR TITLE
1.14: Added missing dependency for defusedxml (needed by nltk>=3.10)

### DIFF
--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -134,6 +134,8 @@ contextlib2==0.6.0
 # cryptography is used by Authlib, which us used by safety
 cryptography==47.0.0; python_version == '3.8'
 cryptography==48.0.1; python_version >= '3.9'
+# defusedxml is used by nltk>=3.10.0
+defusedxml==0.7.1; python_version >= '3.10'
 distlib==0.3.7
 # safety 3.4.0 depends on filelock~=3.16.1
 filelock==3.16.1; python_version <= '3.9'


### PR DESCRIPTION
Backports #981 into 1.14.