### PR TITLE
Fixed uuid error in "zhmc storagevolume update" command

### DIFF
--- a/changes/1001.fix.rst
+++ b/changes/1001.fix.rst
@@ -1,0 +1,3 @@
+Fixed the error that the "zhmc storagevolume update" command has put its
+"uuid" option into the request payload as a storage volume property to be
+changed.

--- a/zhmccli/_cmd_storagevolume.py
+++ b/zhmccli/_cmd_storagevolume.py
@@ -425,6 +425,8 @@ def cmd_storagevolume_update(cmd_ctx, stogrp_name, stovol_name_or_uuid,
         # The following options are handled in this function:
         'email-to-address': None,
         'email-cc-address': None,
+        # The following options should not be passed on:
+        'uuid': None,
     }
     org_options = original_options(options)
     properties = options_to_properties(org_options, name_map)


### PR DESCRIPTION
For details, see the commit message.
No review needed.