### PR TITLE
1.14: Fixed zhmcclient upgrade version for Python 3.8

### DIFF
--- a/changes/noissue.zhmcclient.fix.rst
+++ b/changes/noissue.zhmcclient.fix.rst
@@ -1,1 +1,2 @@
-Upgraded zhmcclient to 1.26.0 to pick up fixes.
+Upgraded zhmcclient to pick up fixes. For Python 3.8, upgraded zhmcclient to
+1.24.1. For Python >= 3.9, upgraded zhmcclient to 1.26.0.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -17,7 +17,8 @@ wheel==0.46.2; python_version >= '3.9'
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-zhmcclient==1.26.0
+zhmcclient==1.24.1; python_version == '3.8'
+zhmcclient==1.26.0; python_version >= '3.9'
 
 click==8.0.2
 click-repl==0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.26.0
+zhmcclient>=1.24.1; python_version == '3.8'
+zhmcclient>=1.26.0; python_version >= '3.9'
 
 # safety 2.2.0 depends on click>=8.0.2
 # click-repl 0.2/0.3 fails with click>=8.2,


### PR DESCRIPTION
No review needed.