### PR TITLE
Improve performance of list adapters command

### DIFF
--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -295,12 +295,6 @@ def cmd_adapter_list(cmd_ctx, cpc_name, options):
     client = zhmcclient.Client(cmd_ctx.session)
     cpc = find_cpc(cmd_ctx, client, cpc_name)
 
-    filter_args = build_filter_args(cmd_ctx, options['filter'])
-    try:
-        adapters = cpc.adapters.list(filter_args=filter_args)
-    except zhmcclient.Error as exc:
-        raise click_exception(exc, cmd_ctx.error_format)
-
     if options['type']:
         click.echo("The --type option is deprecated and type information "
                    "is now always shown.")
@@ -325,6 +319,25 @@ def cmd_adapter_list(cmd_ctx, cpc_name, options):
         show_list.extend([
             'object-uri',
         ])
+
+    standard_props = ['name', 'adapter-id', 'adapter-family', 'type', 'status',
+                      'firmware-update-pending', 'cpc-name', 'cpc-object-uri',
+                      'se-version', 'dpm-enabled', 'cpc']
+    additional_props = [p for p in show_list if p not in standard_props]
+
+    filter_args = build_filter_args(cmd_ctx, options['filter'])
+    console_features = client.consoles.console.list_api_features()
+    if ('adapter-network-information' in console_features):
+        try:
+            adapters = client.consoles.console.list_permitted_adapters(
+                additional_properties=additional_props, filter_args=filter_args)
+        except zhmcclient.Error as exc:
+            raise click_exception(exc, cmd_ctx.error_format)
+    else:
+        try:
+            adapters = cpc.adapters.list(filter_args=filter_args)
+        except zhmcclient.Error as exc:
+            raise click_exception(exc, cmd_ctx.error_format)
 
     cpc_additions = {}
     for adapter in adapters:

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -327,10 +327,12 @@ def cmd_adapter_list(cmd_ctx, cpc_name, options):
 
     filter_args = build_filter_args(cmd_ctx, options['filter'])
     console_features = client.consoles.console.list_api_features()
+    already_loaded_props = set()
     if ('adapter-network-information' in console_features):
         try:
             adapters = client.consoles.console.list_permitted_adapters(
                 additional_properties=additional_props, filter_args=filter_args)
+            already_loaded_props.update(show_list)
         except zhmcclient.Error as exc:
             raise click_exception(exc, cmd_ctx.error_format)
     else:
@@ -349,7 +351,8 @@ def cmd_adapter_list(cmd_ctx, cpc_name, options):
     sort_props = build_sort_props(cmd_ctx, options['sort'], default=['name'])
     try:
         print_resources(cmd_ctx, adapters, cmd_ctx.output_format, show_list,
-                        additions, all=options['all'], sort_props=sort_props)
+                        additions, all=options['all'], sort_props=sort_props,
+                        local_only_props=already_loaded_props)
     except zhmcclient.Error as exc:
         raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_cmd_adapter.py
+++ b/zhmccli/_cmd_adapter.py
@@ -327,17 +327,17 @@ def cmd_adapter_list(cmd_ctx, cpc_name, options):
 
     filter_args = build_filter_args(cmd_ctx, options['filter'])
     console_features = client.consoles.console.list_api_features()
-    already_loaded_props = set()
     if ('adapter-network-information' in console_features):
         try:
             adapters = client.consoles.console.list_permitted_adapters(
                 additional_properties=additional_props, filter_args=filter_args)
-            already_loaded_props.update(show_list)
+            already_loaded_props = show_list
         except zhmcclient.Error as exc:
             raise click_exception(exc, cmd_ctx.error_format)
     else:
         try:
             adapters = cpc.adapters.list(filter_args=filter_args)
+            already_loaded_props = standard_props
         except zhmcclient.Error as exc:
             raise click_exception(exc, cmd_ctx.error_format)
 

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -713,7 +713,7 @@ def print_properties(cmd_ctx, properties, output_format, show_list=None):
 
 def print_resources(
         cmd_ctx, resources, output_format, show_list, additions=None,
-        all=False, sort_props=None, updates=None, local_only_props=set()):
+        all=False, sort_props=None, updates=None, local_only_props=None):
     # pylint: disable=redefined-builtin
     """
     Print the properties of a list of resources in the desired output format.

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -1251,7 +1251,7 @@ def print_resources_as_json(
         Names of resource properties that should not be pulled from remote
         if they are not cached. If the property value is not cached, the
         corresponding field in the JSON output is `null`. If `None`, all
-        properties may be pulled from remote. 
+        properties may be pulled from remote.
 
     Raises:
         zhmcclient.HTTPError
@@ -1426,7 +1426,7 @@ def print_resources_as_csv(
       local_only_props (iterable of str):
         Names of resource properties that should not be pulled from remote
         if they are not cached. If the property value is not cached, the
-        corresponding field in the CSV output is empty. If `None`, all 
+        corresponding field in the CSV output is empty. If `None`, all
         properties may be pulled from remote.
 
     Raises:

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -962,8 +962,9 @@ def print_resources_as_table(
 
       local_only_props (iterable of str):
         Names of resource properties that should not be pulled from remote
-        if they are not cached. If `None`, all properties may be pulled from
-        remote.
+        if they are not cached. If the property value is not cached, the
+        corresponding field in the table is empty. If `None`, all properties
+        may be pulled from remote.
 
     Raises:
         zhmcclient.HTTPError
@@ -1248,8 +1249,9 @@ def print_resources_as_json(
 
       local_only_props (iterable of str):
         Names of resource properties that should not be pulled from remote
-        if they are not cached. If `None`, all properties may be pulled from
-        remote.
+        if they are not cached. If the property value is not cached, the
+        corresponding field in the JSON output is `null`. If `None`, all
+        properties may be pulled from remote. 
 
     Raises:
         zhmcclient.HTTPError
@@ -1423,8 +1425,9 @@ def print_resources_as_csv(
 
       local_only_props (iterable of str):
         Names of resource properties that should not be pulled from remote
-        if they are not cached. If `None`, all properties may be pulled from
-        remote.
+        if they are not cached. If the property value is not cached, the
+        corresponding field in the CSV output is empty. If `None`, all 
+        properties may be pulled from remote.
 
     Raises:
         zhmcclient.HTTPError

--- a/zhmccli/_helper.py
+++ b/zhmccli/_helper.py
@@ -713,7 +713,7 @@ def print_properties(cmd_ctx, properties, output_format, show_list=None):
 
 def print_resources(
         cmd_ctx, resources, output_format, show_list, additions=None,
-        all=False, sort_props=None, updates=None):
+        all=False, sort_props=None, updates=None, local_only_props=set()):
     # pylint: disable=redefined-builtin
     """
     Print the properties of a list of resources in the desired output format.
@@ -763,6 +763,11 @@ def print_resources(
         matched by index.
         If `None`, no updates are defined.
 
+      local_only_props (iterable of str):
+        Names of resource properties that should not be pulled from remote
+        if they are not cached. If `None`, all properties may be pulled from
+        remote.
+
     Raises:
         InvalidOutputFormatError
         zhmcclient.HTTPError
@@ -775,13 +780,15 @@ def print_resources(
             output_format = 'psql'
         print_resources_as_table(
             cmd_ctx, resources, output_format, show_list, additions, all,
-            sort_props, updates)
+            sort_props, updates, local_only_props)
     elif output_format == 'json':
         print_resources_as_json(
-            cmd_ctx, resources, show_list, additions, all, sort_props, updates)
+            cmd_ctx, resources, show_list, additions, all, sort_props, updates,
+            local_only_props)
     elif output_format == 'csv':
         print_resources_as_csv(
-            cmd_ctx, resources, show_list, additions, all, sort_props, updates)
+            cmd_ctx, resources, show_list, additions, all, sort_props, updates,
+            local_only_props)
     else:
         raise InvalidOutputFormatError(output_format)
 
@@ -895,7 +902,7 @@ def print_properties_as_table(
 
 def print_resources_as_table(
         cmd_ctx, resources, table_format, show_list, additions=None,
-        all=False, sort_props=None, updates=None):
+        all=False, sort_props=None, updates=None, local_only_props=None):
     # pylint: disable=redefined-builtin
     """
     Print resources in tabular output format.
@@ -953,6 +960,11 @@ def print_resources_as_table(
         matched by index.
         If `None`, no updates are defined.
 
+      local_only_props (iterable of str):
+        Names of resource properties that should not be pulled from remote
+        if they are not cached. If `None`, all properties may be pulled from
+        remote.
+
     Raises:
         zhmcclient.HTTPError
         zhmcclient.ParseError
@@ -962,7 +974,8 @@ def print_resources_as_table(
     inner_format = INNER_TABLE_FORMAT.get(table_format, table_format)
 
     props_list, prop_names = get_resource_list(
-        cmd_ctx, resources, show_list, additions, all, sort_props, updates)
+        cmd_ctx, resources, show_list, additions, all, sort_props, updates,
+        local_only_props)
 
     table = []
     for props in props_list:
@@ -1185,7 +1198,7 @@ def print_properties_as_json(cmd_ctx, properties, show_list=None):
 
 def print_resources_as_json(
         cmd_ctx, resources, show_list, additions=None, all=False,
-        sort_props=None, updates=None):
+        sort_props=None, updates=None, local_only_props=None):
     # pylint: disable=redefined-builtin
     """
     Print resources in JSON output format.
@@ -1233,6 +1246,11 @@ def print_resources_as_json(
         matched by index.
         If `None`, no updates are defined.
 
+      local_only_props (iterable of str):
+        Names of resource properties that should not be pulled from remote
+        if they are not cached. If `None`, all properties may be pulled from
+        remote.
+
     Raises:
         zhmcclient.HTTPError
         zhmcclient.ParseError
@@ -1240,7 +1258,8 @@ def print_resources_as_json(
         zhmcclient.ConnectionError
     """
     props_list, _ = get_resource_list(
-        cmd_ctx, resources, show_list, additions, all, sort_props, updates)
+        cmd_ctx, resources, show_list, additions, all, sort_props, updates,
+        local_only_props)
     json_str = json.dumps(props_list)
     cmd_ctx.spinner.stop()
     click.echo(json_str)
@@ -1354,7 +1373,7 @@ def print_properties_as_csv(cmd_ctx, properties, show_list=None):
 
 def print_resources_as_csv(
         cmd_ctx, resources, show_list, additions=None, all=False,
-        sort_props=None, updates=None):
+        sort_props=None, updates=None, local_only_props=None):
     # pylint: disable=redefined-builtin
     """
     Print resources in CSV output format.
@@ -1402,6 +1421,11 @@ def print_resources_as_csv(
         matched by index.
         If `None`, no updates are defined.
 
+      local_only_props (iterable of str):
+        Names of resource properties that should not be pulled from remote
+        if they are not cached. If `None`, all properties may be pulled from
+        remote.
+
     Raises:
         zhmcclient.HTTPError
         zhmcclient.ParseError
@@ -1409,7 +1433,8 @@ def print_resources_as_csv(
         zhmcclient.ConnectionError
     """
     props_list, prop_names = get_resource_list(
-        cmd_ctx, resources, show_list, additions, all, sort_props, updates)
+        cmd_ctx, resources, show_list, additions, all, sort_props, updates,
+        local_only_props)
     writer = csv.DictWriter(
         sys.stdout, fieldnames=prop_names, lineterminator="\n",
         delimiter=CSV_DELIM, quotechar=CSV_QUOTE, quoting=CSV_QUOTING)
@@ -1478,7 +1503,8 @@ def print_dicts_as_csv(
 
 
 def get_resource_list(
-        cmd_ctx, resources, show_list, additions, all, sort_props, updates):
+        cmd_ctx, resources, show_list, additions, all, sort_props, updates,
+        local_only_props=None):
     # pylint: disable=redefined-builtin
     """
     Return a list of resource properties, ready for output.
@@ -1580,6 +1606,9 @@ def get_resource_list(
                 props_needed = show_list
             props_to_pull = [name for name in props_needed
                              if name not in resource.properties]
+            if local_only_props:
+                props_to_pull = [name for name in props_to_pull
+                                 if name not in local_only_props]
             if props_to_pull:
                 try:
                     resource.pull_properties(props_to_pull)


### PR DESCRIPTION
Uses the list permitted adapters API with the additional parameters query parameter when available to avoid get adapter properties roundtrip per adapter.

Fixes #1026 